### PR TITLE
[JS] Bugfix URL encoding

### DIFF
--- a/javascript/lib/api/src/auth/auth-provider.ts
+++ b/javascript/lib/api/src/auth/auth-provider.ts
@@ -116,8 +116,7 @@ class ImmutableURL implements DittoURL {
 
   toString(): string {
     const theParams = this.queryParams.length > 0 ? `?${this.queryParams.join('&')}` : '';
-    const theEncodedParams = encodeURIComponent(theParams);
-    return `${this.protocol}://${this.domain}${this.path}${theEncodedParams}`;
+    return `${this.protocol}://${this.domain}${this.path}${theParams}`;
   }
 
 }


### PR DESCRIPTION
This is a bugfix that arises with URL encoding of extra query params provided by the user for the authentication step. Encoding the params automatically causes trouble like encoded '=' signs which will then be not readable by REST controllers