### PR TITLE
Make scoped js packages publishable

### DIFF
--- a/javascript/lib/api/package.json
+++ b/javascript/lib/api/package.json
@@ -9,6 +9,9 @@
   "module": "dist/index.es.js",
   "browser": "dist/index.bundle.js",
   "types": "dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist"
   ],

--- a/javascript/lib/dom/package.json
+++ b/javascript/lib/dom/package.json
@@ -9,6 +9,9 @@
   "main": "./dist/index.js",
   "browser": "./dist/index.bundle.js",
   "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist"
   ],

--- a/javascript/lib/node/package.json
+++ b/javascript/lib/node/package.json
@@ -7,6 +7,9 @@
   "license": "SEE LICENSE IN LICENSE",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
The scoped packages need a special configuration to make them publishable via lerna (see https://github.com/lerna/lerna/tree/master/commands/publish#publishconfigaccess).

Signed-off-by: Florian Fendt <Florian.Fendt@bosch-si.com>