### PR TITLE
added flatten-maven-plugin and configured it to flatten the pom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .checkstyle
 .classpath
 .idea
+.flattened-pom.xml
 *.iml
 .project
 .settings

--- a/java/README.md
+++ b/java/README.md
@@ -52,12 +52,19 @@ AuthenticationProvider authenticationProvider =
 or JWT authentication:
 
 ```java
+// optionally define a proxy server to use
+ProxyConfiguration proxyConfig = ProxyConfiguration.newBuilder()
+    .proxyHost("localhost")
+    .proxyPort(3128)
+    .build();
+
 AuthenticationProvider authenticationProvider =
     AuthenticationProviders.clientCredentials(ClientCredentialsAuthenticationConfiguration.newBuilder()
         .clientId("my-oauth-client-id")
         .clientSecret("my-oauth-client-secret")
         .scopes("offline_access email")
         .tokenEndpoint("https://my-oauth-provider/oauth/token")
+        .proxyConfiguration(proxyConfig) // optionally configure a proxy server
         .build());
 ```
 
@@ -65,11 +72,8 @@ AuthenticationProvider authenticationProvider =
 MessagingProvider messagingProvider = MessagingProviders.webSocket(WebSocketMessagingConfiguration.newBuilder()
     .endpoint("wss://ditto.eclipse.org")
     .jsonSchemaVersion(JsonSchemaVersion.V_1)
-    // optionally configure a proxy server or a truststore containing the trusted CAs for SSL connection establishment
-    .proxyConfiguration(ProxyConfiguration.newBuilder()
-        .proxyHost("localhost")
-        .proxyPort(3128)
-        .build())
+    .proxyConfiguration(proxyConfig) // optionally configure a proxy server
+    // optionally configure a truststore containing the trusted CAs for SSL connection establishment
     .trustStoreConfiguration(TrustStoreConfiguration.newBuilder()
         .location(TRUSTSTORE_LOCATION)
         .password(TRUSTSTORE_PASSWORD)

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -282,6 +282,12 @@
                     <version>3.0.2</version>
                 </plugin>
 
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.0.1</version>
+                </plugin>
+
                 <!-- Declaration for the 3 following plugins is explicitly needed by Maven 3 -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -461,6 +467,32 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <flattenMode>ossrh</flattenMode>
+                    <updatePomFile>true</updatePomFile>
+                </configuration>
+                <executions>
+                    <!-- enable flattening -->
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <!-- ensure proper cleanup -->
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
in order to get released pom in a working state with resolved version/revision placeholders

Milestone 1.0.0-M2 did contain non resolved `${revision}` placeholder which results in non-resolvable transitive Ditto dependencies.
This fixes that for the upcoming M3 release.