### PR TITLE
Improved javadoc of client credentials authentication configuration

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/configuration/ClientCredentialsAuthenticationConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/ClientCredentialsAuthenticationConfiguration.java
@@ -181,6 +181,8 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
 
         /**
          * Sets the client secret to authenticate.
+         * <p/>
+         * The secret will <strong>never</strong> be sent to a Ditto backend but directly to the configured endpoint.
          *
          * @param clientSecret the client secret.
          * @return this builder.


### PR DESCRIPTION
Added javadoc to clarify that client secrets are never sent to a Ditto backend.