### PR TITLE
Response header mapping adjustments for Ditto PR

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -203,7 +203,7 @@
         <logback.version>1.2.3</logback.version>
         <junit.version>4.12</junit.version>
         <assertj.version>3.11.1</assertj.version>
-        <mutability-detector.version>0.9.6</mutability-detector.version>
+        <mutability-detector.version>0.10.2</mutability-detector.version>
         <equals-verifier.version>3.0.3</equals-verifier.version>
         <mockito.version>2.9.0</mockito.version>
         <jsonassert.version>1.2.3</jsonassert.version>

--- a/java/src/main/java/org/eclipse/ditto/client/internal/DefaultDittoClient.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/DefaultDittoClient.java
@@ -165,9 +165,8 @@ public final class DefaultDittoClient implements DittoClient {
         final String name = TopicPath.Channel.TWIN.getName();
         final PointerBus bus = BusFactory.createPointerBus(name, messagingProvider.getExecutorService());
         init(bus, messagingProvider, responseForwarder);
-        final String sessionId = messagingProvider.getAuthenticationConfiguration().getSessionId();
         final JsonSchemaVersion schemaVersion = messagingProvider.getMessagingConfiguration().getJsonSchemaVersion();
-        final OutgoingMessageFactory messageFactory = OutgoingMessageFactory.newInstance(schemaVersion, sessionId);
+        final OutgoingMessageFactory messageFactory = OutgoingMessageFactory.newInstance(schemaVersion);
         return TwinImpl.newInstance(messagingProvider, responseForwarder, messageFactory, bus);
     }
 
@@ -178,7 +177,7 @@ public final class DefaultDittoClient implements DittoClient {
         init(bus, messagingProvider, responseForwarder);
         final String sessionId = messagingProvider.getAuthenticationConfiguration().getSessionId();
         final JsonSchemaVersion schemaVersion = messagingProvider.getMessagingConfiguration().getJsonSchemaVersion();
-        final OutgoingMessageFactory messageFactory = OutgoingMessageFactory.newInstance(schemaVersion, sessionId);
+        final OutgoingMessageFactory messageFactory = OutgoingMessageFactory.newInstance(schemaVersion);
         return LiveImpl.newInstance(messagingProvider, responseForwarder, messageFactory, bus, schemaVersion,
                 sessionId, messageSerializerRegistry);
     }

--- a/java/src/main/java/org/eclipse/ditto/client/internal/OutgoingMessageFactory.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/OutgoingMessageFactory.java
@@ -389,7 +389,6 @@ public final class OutgoingMessageFactory {
         final DittoHeadersBuilder headersBuilder = DittoHeaders.newBuilder()
                 .correlationId(UUID.randomUUID().toString())
                 .schemaVersion(jsonSchemaVersion)
-                .source(sessionId)
                 .responseRequired(modify.isResponseRequired().orElse(true));
         modify.exists().ifPresent(exists -> {
             if (!allowExists) {

--- a/java/src/main/java/org/eclipse/ditto/client/internal/OutgoingMessageFactory.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/OutgoingMessageFactory.java
@@ -84,26 +84,21 @@ public final class OutgoingMessageFactory {
             EntityTagMatchers.fromList(Collections.singletonList(EntityTagMatcher.asterisk()));
 
     private final JsonSchemaVersion jsonSchemaVersion;
-    private final String sessionId;
 
-    private OutgoingMessageFactory(final JsonSchemaVersion jsonSchemaVersion, final String sessionId) {
+    private OutgoingMessageFactory(final JsonSchemaVersion jsonSchemaVersion) {
         this.jsonSchemaVersion = jsonSchemaVersion;
-        this.sessionId = sessionId;
     }
 
     /**
      * Creates a new {@code OutgoingMessageFactory}.
      *
      * @param jsonSchemaVersion the version in which messages should be created by this factory.
-     * @param sessionId the session id of the client.
      * @return the factory.
      * @throws NullPointerException if {@code configuration} is {@code null}.
      */
-    public static OutgoingMessageFactory newInstance(final JsonSchemaVersion jsonSchemaVersion,
-            final String sessionId) {
+    public static OutgoingMessageFactory newInstance(final JsonSchemaVersion jsonSchemaVersion) {
         checkNotNull(jsonSchemaVersion, "jsonSchemaVersion");
-        checkNotNull(sessionId, "sessionId");
-        return new OutgoingMessageFactory(jsonSchemaVersion, sessionId);
+        return new OutgoingMessageFactory(jsonSchemaVersion);
     }
 
     public ThingCommand createThing(final Thing thing, final Option<?>... options) {

--- a/java/src/main/java/org/eclipse/ditto/client/live/events/EventFactory.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/events/EventFactory.java
@@ -36,16 +36,8 @@ public interface EventFactory {
         return DittoHeaders.newBuilder()
                 .correlationId(String.valueOf(UUID.randomUUID()))
                 .schemaVersion(getSchemaVersion())
-                .source(getSource())
                 .build();
     }
-
-    /**
-     * Returns the Source this Client instance represents.
-     *
-     * @return the Source this Client instance represents
-     */
-    String getSource();
 
     /**
      * Returns the JsonSchemaVersion this Client was configured to handle.

--- a/java/src/main/java/org/eclipse/ditto/client/live/events/internal/ImmutableFeatureEventFactory.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/events/internal/ImmutableFeatureEventFactory.java
@@ -52,7 +52,6 @@ public final class ImmutableFeatureEventFactory implements FeatureEventFactory {
     /**
      * Returns an instance of {@code ImmutableFeatureEventFactory}.
      *
-     * @param source the source this client instance represents.
      * @param schemaVersion the JSON schema version this client was configured to handle.
      * @param thingId the ID of the Thing to create events for.
      * @param featureId the ID of the Feature to create events for.
@@ -60,9 +59,9 @@ public final class ImmutableFeatureEventFactory implements FeatureEventFactory {
      * @throws NullPointerException if any argument is {@code null}.
      * @throws IllegalArgumentException if {@code source}, {@code thingId} or {@code featureId} is empty.
      */
-    public static ImmutableFeatureEventFactory getInstance(final String source, final JsonSchemaVersion
-            schemaVersion, final ThingId thingId, final String featureId) {
-        return new ImmutableFeatureEventFactory(ImmutableThingEventFactory.getInstance(source, schemaVersion, thingId),
+    public static ImmutableFeatureEventFactory getInstance(final JsonSchemaVersion schemaVersion,
+            final ThingId thingId, final String featureId) {
+        return new ImmutableFeatureEventFactory(ImmutableThingEventFactory.getInstance(schemaVersion, thingId),
                 argumentNotEmpty(featureId, "Feature ID"));
     }
 
@@ -101,11 +100,6 @@ public final class ImmutableFeatureEventFactory implements FeatureEventFactory {
     public FeaturePropertyModified featurePropertyModified(final JsonPointer propertyJsonPointer,
             final JsonValue propertyJsonValue) {
         return thingEventFactory.featurePropertyModified(featureId, propertyJsonPointer, propertyJsonValue);
-    }
-
-    @Override
-    public String getSource() {
-        return thingEventFactory.getSource();
     }
 
     @Override

--- a/java/src/main/java/org/eclipse/ditto/client/live/events/internal/ImmutableGlobalEventFactory.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/events/internal/ImmutableGlobalEventFactory.java
@@ -61,27 +61,23 @@ import org.eclipse.ditto.signals.events.things.ThingModified;
 @SuppressWarnings({"squid:S1610", "OverlyCoupledClass"})
 public final class ImmutableGlobalEventFactory implements GlobalEventFactory {
 
-    private final String source;
     private final JsonSchemaVersion schemaVersion;
 
-    private ImmutableGlobalEventFactory(final String theSource, final JsonSchemaVersion theSchemaVersion) {
-        source = theSource;
+    private ImmutableGlobalEventFactory(final JsonSchemaVersion theSchemaVersion) {
         schemaVersion = theSchemaVersion;
     }
 
     /**
      * Returns an instance of {@code ImmutableGlobalEventFactory}.
      *
-     * @param source the source this client instance represents.
      * @param schemaVersion the JSON schema version this client was configured to handle.
      * @return the instance.
      * @throws NullPointerException if any argument is {@code null}.
      * @throws IllegalArgumentException if {@code source} is empty.
      */
-    public static ImmutableGlobalEventFactory getInstance(final String source, final JsonSchemaVersion schemaVersion) {
-        argumentNotEmpty(source, "source");
+    public static ImmutableGlobalEventFactory getInstance(final JsonSchemaVersion schemaVersion) {
         checkNotNull(schemaVersion, "schema version");
-        return new ImmutableGlobalEventFactory(source, schemaVersion);
+        return new ImmutableGlobalEventFactory(schemaVersion);
     }
 
     @Override
@@ -204,11 +200,6 @@ public final class ImmutableGlobalEventFactory implements GlobalEventFactory {
     }
 
     @Override
-    public String getSource() {
-        return source;
-    }
-
-    @Override
     public JsonSchemaVersion getSchemaVersion() {
         return schemaVersion;
     }
@@ -222,17 +213,17 @@ public final class ImmutableGlobalEventFactory implements GlobalEventFactory {
             return false;
         }
         final ImmutableGlobalEventFactory that = (ImmutableGlobalEventFactory) o;
-        return Objects.equals(source, that.source) && schemaVersion == that.schemaVersion;
+        return schemaVersion == that.schemaVersion;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(source, schemaVersion);
+        return Objects.hash(getClass(), schemaVersion);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " [" + "source=" + source + ", schemaVersion=" + schemaVersion + "]";
+        return getClass().getSimpleName() + " [" + ", schemaVersion=" + schemaVersion + "]";
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/live/events/internal/ImmutableThingEventFactory.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/events/internal/ImmutableThingEventFactory.java
@@ -67,17 +67,16 @@ public final class ImmutableThingEventFactory implements ThingEventFactory {
     /**
      * Returns an instance of {@code ImmutableThingEventFactory}.
      *
-     * @param source the source this client instance represents.
      * @param schemaVersion the JSON schema version this client was configured to handle.
      * @param thingId the ID of the Thing to create events for.
      * @return the instance.
      * @throws NullPointerException if any argument is {@code null}.
      * @throws IllegalArgumentException if {@code source} or {@code thingId} is empty.
      */
-    public static ImmutableThingEventFactory getInstance(final String source, final JsonSchemaVersion schemaVersion,
+    public static ImmutableThingEventFactory getInstance(final JsonSchemaVersion schemaVersion,
             final ThingId thingId) {
         argumentNotEmpty(thingId, "Thing ID");
-        return new ImmutableThingEventFactory(ImmutableGlobalEventFactory.getInstance(source, schemaVersion), thingId);
+        return new ImmutableThingEventFactory(ImmutableGlobalEventFactory.getInstance(schemaVersion), thingId);
     }
 
     @Override
@@ -178,11 +177,6 @@ public final class ImmutableThingEventFactory implements ThingEventFactory {
     public FeaturePropertyModified featurePropertyModified(final String featureId,
             final JsonPointer propertyJsonPointer, final JsonValue propertyJsonValue) {
         return globalEventFactory.featurePropertyModified(thingId, featureId, propertyJsonPointer, propertyJsonValue);
-    }
-
-    @Override
-    public String getSource() {
-        return globalEventFactory.getSource();
     }
 
     @Override

--- a/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveFeatureHandleImpl.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveFeatureHandleImpl.java
@@ -75,7 +75,6 @@ final class LiveFeatureHandleImpl extends FeatureHandleImpl<LiveThingHandle, Liv
 
     private final MessageSerializerRegistry messageSerializerRegistry;
     private final JsonSchemaVersion schemaVersion;
-    private final String sessionId;
     private final Map<Class<? extends LiveCommand>, Function<? extends LiveCommand, LiveCommandAnswerBuilder.BuildStep>>
             liveCommandsFunctions;
 
@@ -93,7 +92,6 @@ final class LiveFeatureHandleImpl extends FeatureHandleImpl<LiveThingHandle, Liv
 
         this.messageSerializerRegistry = messageSerializerRegistry;
         this.schemaVersion = messagingProvider.getMessagingConfiguration().getJsonSchemaVersion();
-        this.sessionId = messagingProvider.getAuthenticationConfiguration().getSessionId();
 
         liveCommandsFunctions = new IdentityHashMap<>();
     }

--- a/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveFeatureHandleImpl.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveFeatureHandleImpl.java
@@ -186,7 +186,7 @@ final class LiveFeatureHandleImpl extends FeatureHandleImpl<LiveThingHandle, Liv
         argumentNotNull(eventFunction);
 
         final FeatureEventFactory featureEventFactory =
-                ImmutableFeatureEventFactory.getInstance(sessionId, schemaVersion, getThingEntityId(),
+                ImmutableFeatureEventFactory.getInstance(schemaVersion, getThingEntityId(),
                         getFeatureId());
         final Event<?> eventToEmit = eventFunction.apply(featureEventFactory);
         getMessagingProvider().emitEvent(eventToEmit, TopicPath.Channel.LIVE);

--- a/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveImpl.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveImpl.java
@@ -232,8 +232,8 @@ public final class LiveImpl extends CommonManagementImpl<LiveThingHandle, LiveFe
                             }
 
                             if (!handled) {
-                                LOGGER.warn("Incoming live command of type '{}' from source '{}' was not processed.",
-                                        liveCommand.getType(), liveCommand.getDittoHeaders().getSource().orElse("?"));
+                                LOGGER.warn("Incoming live command of type '{}'  was not processed.",
+                                        liveCommand.getType());
                             }
                         })), completableFutureLiveCommands);
         return completableFutureCombined;
@@ -435,7 +435,7 @@ public final class LiveImpl extends CommonManagementImpl<LiveThingHandle, LiveFe
     public void emitEvent(final Function<GlobalEventFactory, Event<?>> eventFunction) {
         argumentNotNull(eventFunction);
 
-        final GlobalEventFactory globalEventFactory = ImmutableGlobalEventFactory.getInstance(sessionId,
+        final GlobalEventFactory globalEventFactory = ImmutableGlobalEventFactory.getInstance(
                 schemaVersion);
         final Event<?> eventToEmit = eventFunction.apply(globalEventFactory);
         getMessagingProvider().emitEvent(eventToEmit, TopicPath.Channel.LIVE);

--- a/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveThingHandleImpl.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveThingHandleImpl.java
@@ -257,7 +257,7 @@ public final class LiveThingHandleImpl extends ThingHandleImpl<LiveThingHandle, 
     public void emitEvent(final Function<ThingEventFactory, Event<?>> eventFunction) {
         argumentNotNull(eventFunction);
 
-        final ThingEventFactory thingEventFactory = ImmutableThingEventFactory.getInstance(sessionId,
+        final ThingEventFactory thingEventFactory = ImmutableThingEventFactory.getInstance(
                 schemaVersion, getThingEntityId());
         final Event<?> eventToEmit = eventFunction.apply(thingEventFactory);
         getMessagingProvider().emitEvent(eventToEmit, TopicPath.Channel.LIVE);

--- a/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveThingHandleImpl.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveThingHandleImpl.java
@@ -88,7 +88,6 @@ public final class LiveThingHandleImpl extends ThingHandleImpl<LiveThingHandle, 
 
     private final MessageSerializerRegistry messageSerializerRegistry;
     private final JsonSchemaVersion schemaVersion;
-    private final String sessionId;
     private final Map<Class<? extends LiveCommand>, Function<? extends LiveCommand, LiveCommandAnswerBuilder.BuildStep>>
             liveCommandsFunctions;
 
@@ -106,7 +105,6 @@ public final class LiveThingHandleImpl extends ThingHandleImpl<LiveThingHandle, 
 
         this.messageSerializerRegistry = messageSerializerRegistry;
         this.schemaVersion = messagingProvider.getMessagingConfiguration().getJsonSchemaVersion();
-        this.sessionId = messagingProvider.getAuthenticationConfiguration().getSessionId();
 
         liveCommandsFunctions = new IdentityHashMap<>();
     }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -469,8 +469,6 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
                 .removeHeader(DittoHeaderDefinition.READ_SUBJECTS.getKey())
                 .removeHeader(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey())
                 .removeHeader(DittoHeaderDefinition.RESPONSE_REQUIRED.getKey())
-                .removeHeader(DittoHeaderDefinition.SOURCE.getKey())
-                .source(sessionId)
                 .build();
     }
 

--- a/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableFeatureEventFactoryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableFeatureEventFactoryTest.java
@@ -31,7 +31,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
  */
 public final class ImmutableFeatureEventFactoryTest {
 
-    private static final String SOURCE = "mySource";
     private static final JsonSchemaVersion SCHEMA_VERSION = JsonSchemaVersion.V_1;
 
     private ImmutableFeatureEventFactory underTest = null;

--- a/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableFeatureEventFactoryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableFeatureEventFactoryTest.java
@@ -41,7 +41,7 @@ public final class ImmutableFeatureEventFactoryTest {
      */
     @Before
     public void setUp() {
-        underTest = ImmutableFeatureEventFactory.getInstance(SOURCE, SCHEMA_VERSION, THING_ID, FLUX_CAPACITOR_ID);
+        underTest = ImmutableFeatureEventFactory.getInstance(SCHEMA_VERSION, THING_ID, FLUX_CAPACITOR_ID);
     }
 
     /**

--- a/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableGlobalEventFactoryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableGlobalEventFactoryTest.java
@@ -27,7 +27,6 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 
 import java.text.MessageFormat;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -65,7 +64,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
  */
 public final class ImmutableGlobalEventFactoryTest {
 
-    private static final String SOURCE = "mySource";
     private static final JsonSchemaVersion SCHEMA_VERSION = JsonSchemaVersion.V_1;
     private static final JsonPointer ATTRIBUTES_POINTER = JsonFactory.newPointer("/attributes");
     private static final JsonPointer ATTRIBUTE_JSON_POINTER = JsonFactory.newPointer("manufacturer/name");

--- a/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableGlobalEventFactoryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableGlobalEventFactoryTest.java
@@ -77,78 +77,38 @@ public final class ImmutableGlobalEventFactoryTest {
 
     private ImmutableGlobalEventFactory underTest = null;
 
-    /**
-     *
-     */
     @Before
     public void setUp() {
-        underTest = ImmutableGlobalEventFactory.getInstance(SOURCE, SCHEMA_VERSION);
+        underTest = ImmutableGlobalEventFactory.getInstance(SCHEMA_VERSION);
     }
 
-    /**
-     *
-     */
     @Test
     public void assertImmutability() {
         assertInstancesOf(ImmutableGlobalEventFactory.class, areImmutable(),
                 provided(JsonSchemaVersion.class, ThingId.class).areAlsoImmutable());
     }
 
-    /**
-     *
-     */
     @Test
     public void testHashCodeAndEquals() {
         EqualsVerifier.forClass(ImmutableGlobalEventFactory.class).usingGetClass().verify();
     }
 
-    /**
-     *
-     */
-    @SuppressWarnings("ConstantConditions")
-    @Test
-    public void tryToGetInstanceWithNullSource() {
-        assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> ImmutableGlobalEventFactory.getInstance(null, SCHEMA_VERSION))
-                .withMessage(MessageFormat.format("The {0} must not be null!", "source"))
-                .withNoCause();
-    }
-
-    /**
-     *
-     */
     @SuppressWarnings("ConstantConditions")
     @Test
     public void tryToGetInstanceWithNullJsonSchemaVersion() {
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> ImmutableGlobalEventFactory.getInstance(SOURCE, null))
+                .isThrownBy(() -> ImmutableGlobalEventFactory.getInstance(null))
                 .withMessage(MessageFormat.format("The {0} must not be null!", "schema version"))
                 .withNoCause();
     }
 
-    /**
-     *
-     */
-    @Test
-    public void getSourceReturnsExpected() {
-        final ImmutableGlobalEventFactory underTest = ImmutableGlobalEventFactory.getInstance(SOURCE, SCHEMA_VERSION);
-
-        Assertions.assertThat(underTest.getSource()).isEqualTo(SOURCE);
-    }
-
-    /**
-     *
-     */
     @Test
     public void getSchemaVersionReturnsExpected() {
-        final ImmutableGlobalEventFactory underTest = ImmutableGlobalEventFactory.getInstance(SOURCE, SCHEMA_VERSION);
+        final ImmutableGlobalEventFactory underTest = ImmutableGlobalEventFactory.getInstance(SCHEMA_VERSION);
 
         assertThat((Object) underTest.getSchemaVersion()).isEqualTo(SCHEMA_VERSION);
     }
 
-    /**
-     *
-     */
     @Test
     public void thingCreatedReturnsExpected() {
         final ThingCreated thingCreated = underTest.thingCreated(THING_V1);
@@ -161,13 +121,9 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(thingCreated.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
-    /**
-     *
-     */
     @Test
     public void thingDeletedReturnsExpected() {
         final ThingDeleted thingDeleted = underTest.thingDeleted(THING_ID);
@@ -180,13 +136,9 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(thingDeleted.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
-    /**
-     *
-     */
     @Test
     public void thingModifiedReturnsExpected() {
         final ThingModified thingModified = underTest.thingModified(THING_V1);
@@ -199,13 +151,9 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(thingModified.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
-    /**
-     *
-     */
     @Test
     public void attributeCreatedReturnsExpected() {
         final AttributeCreated attributeCreated =
@@ -220,8 +168,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(attributeCreated.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -240,8 +187,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(attributeDeleted.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -261,8 +207,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(attributeModified.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -281,8 +226,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(attributesCreated.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -301,8 +245,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(attributesDeleted.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -321,8 +264,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(attributesModified.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -341,8 +283,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featureCreated.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -361,8 +302,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featureDeleted.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -381,8 +321,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featureModified.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -401,8 +340,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featuresCreated.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -421,8 +359,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featuresDeleted.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -441,8 +378,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featuresModified.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -462,8 +398,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featurePropertiesCreated.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -483,8 +418,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featurePropertiesDeleted.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -504,8 +438,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featurePropertiesModified.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -526,8 +459,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featurePropertyCreated.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -548,8 +480,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featurePropertyDeleted.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
     /**
@@ -570,19 +501,7 @@ public final class ImmutableGlobalEventFactoryTest {
                 .hasRevision(-1);
         assertThat(featurePropertyModified.getDittoHeaders())
                 .hasCorrelationId()
-                .hasSchemaVersion(underTest.getSchemaVersion())
-                .hasSource(underTest.getSource());
-    }
-
-    /**
-     *
-     */
-    @Test
-    public void toStringReturnsExpected() {
-        Assertions.assertThat(underTest.toString())
-                .contains(underTest.getClass().getSimpleName())
-                .contains("source=", SOURCE)
-                .contains("schemaVersion=", SCHEMA_VERSION.toString());
+                .hasSchemaVersion(underTest.getSchemaVersion());
     }
 
 }

--- a/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableThingEventFactoryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableThingEventFactoryTest.java
@@ -41,7 +41,7 @@ public final class ImmutableThingEventFactoryTest {
      */
     @Before
     public void setUp() {
-        underTest = ImmutableThingEventFactory.getInstance(SOURCE, SCHEMA_VERSION, TestConstants.Thing.THING_ID);
+        underTest = ImmutableThingEventFactory.getInstance(SCHEMA_VERSION, TestConstants.Thing.THING_ID);
     }
 
     /**

--- a/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableThingEventFactoryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/live/events/internal/ImmutableThingEventFactoryTest.java
@@ -31,7 +31,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
  */
 public final class ImmutableThingEventFactoryTest {
 
-    private static final String SOURCE = "mySource";
     private static final JsonSchemaVersion SCHEMA_VERSION = JsonSchemaVersion.V_1;
 
     private ImmutableThingEventFactory underTest = null;


### PR DESCRIPTION
These are the necessary adjustments to Ditto Java client for PR https://github.com/eclipse/ditto/pull/557

The `DittoHeader` `"source"` was removed there which was still used in the client (but only for logging), so the usage of this header was also removed.