### PR TITLE
Set response-required to false if no response consumer is specified

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/live/messages/internal/ImmutableMessageSender.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/messages/internal/ImmutableMessageSender.java
@@ -135,6 +135,10 @@ public final class ImmutableMessageSender<T> implements MessageSender<T> {
                         .timestamp(messageTimestamp)
                         .correlationId(messageCorrelationId);
 
+        if (responseConsumer == null) {
+            messageHeadersBuilder.responseRequired(false);
+        }
+
         if (null != messageStatusCode) {
             if (messageStatusCode == HttpStatusCode.NO_CONTENT && payload != null) {
                 final String warnMessage = "StatusCode '" + HttpStatusCode.NO_CONTENT + "' cannot be used in "


### PR DESCRIPTION
Otherwise the header is not present at all which is interpreted by Ditto as required. See https://github.com/eclipse/ditto/issues/616