### PR TITLE
Throw correct failure of AuthenticationException

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -71,7 +71,7 @@ AuthenticationProvider authenticationProvider =
 ```java
 MessagingProvider messagingProvider = MessagingProviders.webSocket(WebSocketMessagingConfiguration.newBuilder()
     .endpoint("wss://ditto.eclipse.org")
-    .jsonSchemaVersion(JsonSchemaVersion.V_1)
+    .jsonSchemaVersion(JsonSchemaVersion.V_2)
     .proxyConfiguration(proxyConfig) // optionally configure a proxy server
     // optionally configure a truststore containing the trusted CAs for SSL connection establishment
     .trustStoreConfiguration(TrustStoreConfiguration.newBuilder()

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/AuthenticationException.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/AuthenticationException.java
@@ -52,7 +52,7 @@ public class AuthenticationException extends RuntimeException {
     }
 
     /**
-     * Creates an AutenticationException for the {@code status code its {@code reason}.
+     * Creates an AutenticationException for the {@code status} code its {@code reason}.
      * @param sessionId the sessionId that failed to authenticate.
      * @param cause the cause of the failure.
      * @param status the status code of the failure.

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/AuthenticationException.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/AuthenticationException.java
@@ -30,6 +30,9 @@ public class AuthenticationException extends RuntimeException {
     private static final String FORBIDDEN_MESSAGE_TEMPLATE =
             "Authentication of session <%s> failed because of insufficient permissions.";
 
+    private static final String STATUS_MESSAGE_TEMPLATE =
+            "Authentication of session <%s> failed with status <%d> and reason: %s";
+
     private static final long serialVersionUID = 4405868587578425044L;
 
     private AuthenticationException(final String message, final Throwable cause) {
@@ -46,6 +49,22 @@ public class AuthenticationException extends RuntimeException {
 
     public static AuthenticationException forbidden(final String sessionId, final Throwable cause) {
         return new AuthenticationException(String.format(FORBIDDEN_MESSAGE_TEMPLATE, sessionId), cause);
+    }
+
+    /**
+     * Creates an AutenticationException for the {@code status code its {@code reason}.
+     * @param sessionId the sessionId that failed to authenticate.
+     * @param cause the cause of the failure.
+     * @param status the status code of the failure.
+     * @param reason a reason message for the failure.
+     * @return the AuthenticationException with the provided information.
+     * @since 1.1.0
+     */
+    public static AuthenticationException withStatus(final String sessionId, final Throwable cause,
+            final int status, final String reason) {
+        return new AuthenticationException(
+                String.format(STATUS_MESSAGE_TEMPLATE, sessionId, status, reason),
+                cause);
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -296,6 +296,10 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
                 throw AuthenticationException.unauthorized(sessionId, cause);
             } else if (isForbidden((WebSocketException) cause)) {
                 throw AuthenticationException.forbidden(sessionId, cause);
+            } else if (cause instanceof OpeningHandshakeException) {
+                final StatusLine statusLine = ((OpeningHandshakeException) cause).getStatusLine();
+                throw AuthenticationException.withStatus(sessionId, cause, statusLine.getStatusCode(),
+                        statusLine.getReasonPhrase());
             }
         }
 

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -286,7 +286,10 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
 
     private <T> T handleExecutionException(final ExecutionException e) {
         final Throwable cause = e.getCause();
-        if (cause instanceof WebSocketException) {
+        if (cause instanceof AuthenticationException) {
+            // no unneccessary boxing of AuthenticationException
+            throw ((AuthenticationException) cause);
+        } else if (cause instanceof WebSocketException) {
             LOGGER.error("Got exception: {}", cause.getMessage());
 
             if (isAuthenticationException((WebSocketException) cause)) {
@@ -295,6 +298,7 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
                 throw AuthenticationException.forbidden(sessionId, cause);
             }
         }
+
         throw AuthenticationException.of(sessionId, e);
     }
 


### PR DESCRIPTION
Fixes unnecessary boxing of AuthenticationException objects in the WebSocketMessagingProvider. 

The AuthenticationException containing the correct failure reason was only to be found at the bottom of the stack trace.

With this PR, the correct exception will stay on top of the stack trace and additionally if we know the failure code, this will be printed in the exceptions message.