### PR TITLE
Create interfaces for options

### DIFF
--- a/javascript/lib/api/README.md
+++ b/javascript/lib/api/README.md
@@ -40,7 +40,7 @@ The client provides different handles to handle requests for specific parts of t
 const thingsHandle = client.getThingsHandle();
 ```
 
-The handles' methods will send requests and return their responses asynchronously. 
+The handles' methods will send requests and return their responses asynchronously.
 For example the code to update a Thing would look like this:
 ```
 const thing = new Thing('the:thing');
@@ -50,7 +50,7 @@ thingsHandle.putThing(thing)
 
 Additionally options for requests can be specified and passed on to the methods:
 ```
-const options = FieldsOptions.getInstance();
+const options = DefaultFieldsOptions.getInstance();
 options.ifMatch('A Tag').withFields('thingId', 'policyId', '_modified');
 thingsHandle.getThing('Testthing:TestId', options)
   .then(returnedThing => {

--- a/javascript/lib/api/src/client/handles/messages-http.ts
+++ b/javascript/lib/api/src/client/handles/messages-http.ts
@@ -12,7 +12,7 @@
  */
 
 /* tslint:disable:no-duplicate-string */
-import { MessagesOptions } from '../../options/request.options';
+import { MessagesOptions, DefaultMessagesOptions } from '../../options/request.options';
 import { RequestSender, RequestSenderFactory } from '../request-factory/request-sender';
 import { MessagesHandle } from './messages';
 import { GenericResponse } from '../../model/response';
@@ -107,7 +107,7 @@ export class DefaultHttpMessagesHandle implements HttpMessagesHandle {
    * @returns A Promise for the server response
    */
   claim(thingId: string, claimMessage: any, options?: MessagesOptions): Promise<GenericResponse> {
-    const messageOptions = options === undefined ? MessagesOptions.getInstance() : options;
+    const messageOptions = options === undefined ? DefaultMessagesOptions.getInstance() : options;
     messageOptions.addHeader('Content-Type', 'application/json');
     return this.requestFactory.fetchRequest({
       verb: 'POST',
@@ -130,7 +130,7 @@ export class DefaultHttpMessagesHandle implements HttpMessagesHandle {
    */
   messageToThing(thingId: string, messageSubject: string, message: string,
                  contentType: string = 'application/json', options?: MessagesOptions): Promise<GenericResponse> {
-    const messageOptions = options === undefined ? MessagesOptions.getInstance() : options;
+    const messageOptions = options === undefined ? DefaultMessagesOptions.getInstance() : options;
     messageOptions.addHeader('Content-Type', contentType);
     return this.requestFactory.fetchRequest({
       verb: 'POST',
@@ -153,7 +153,7 @@ export class DefaultHttpMessagesHandle implements HttpMessagesHandle {
    */
   messageFromThing(thingId: string, messageSubject: string, message: string,
                    contentType: string = 'application/json', options?: MessagesOptions): Promise<GenericResponse> {
-    const messageOptions = options === undefined ? MessagesOptions.getInstance() : options;
+    const messageOptions = options === undefined ? DefaultMessagesOptions.getInstance() : options;
     messageOptions.addHeader('Content-Type', contentType);
     return this.requestFactory.fetchRequest({
       verb: 'POST',
@@ -178,7 +178,7 @@ export class DefaultHttpMessagesHandle implements HttpMessagesHandle {
   messageToFeature(thingId: string, featureId: string, messageSubject: string, message: string,
                    contentType: string = 'application/json', options?: MessagesOptions):
     Promise<GenericResponse> {
-    const messageOptions = options === undefined ? MessagesOptions.getInstance() : options;
+    const messageOptions = options === undefined ? DefaultMessagesOptions.getInstance() : options;
     messageOptions.addHeader('Content-Type', contentType);
     return this.requestFactory.fetchRequest({
       verb: 'POST',
@@ -203,7 +203,7 @@ export class DefaultHttpMessagesHandle implements HttpMessagesHandle {
   messageFromFeature(thingId: string, featureId: string, messageSubject: string, message: string,
                      contentType: string = 'application/json', options?: MessagesOptions):
     Promise<GenericResponse> {
-    const messageOptions = options === undefined ? MessagesOptions.getInstance() : options;
+    const messageOptions = options === undefined ? DefaultMessagesOptions.getInstance() : options;
     messageOptions.addHeader('Content-Type', contentType);
     return this.requestFactory.fetchRequest({
       verb: 'POST',

--- a/javascript/lib/api/src/client/handles/things.ts
+++ b/javascript/lib/api/src/client/handles/things.ts
@@ -14,7 +14,7 @@
 /* tslint:disable:no-duplicate-string */
 import { GenericResponse, PutResponse } from '../../model/response';
 import { Acl, AclEntry, Thing } from '../../model/things.model';
-import { FieldsOptions, GetThingsOptions, MatchOptions } from '../../options/request.options';
+import { FieldsOptions, GetThingsOptions, MatchOptions, DefaultGetThingsOptions } from '../../options/request.options';
 import { RequestSender, RequestSenderFactory } from '../request-factory/request-sender';
 import { HttpThingsHandleV1, HttpThingsHandleV2, WebSocketThingsHandle } from './things.interfaces';
 
@@ -134,7 +134,7 @@ export class DefaultThingsHandle implements WebSocketThingsHandle, HttpThingsHan
   public getThings(thingIds: string[], options?: GetThingsOptions): Promise<Thing[]> {
     let actualOptions: GetThingsOptions;
     if (options === undefined) {
-      actualOptions = GetThingsOptions.getInstance().setThingIds(thingIds);
+      actualOptions = DefaultGetThingsOptions.getInstance().setThingIds(thingIds);
     } else {
       actualOptions = options.setThingIds(thingIds);
     }

--- a/javascript/lib/api/src/options/request.options.ts
+++ b/javascript/lib/api/src/options/request.options.ts
@@ -153,7 +153,7 @@ export interface RequestOptionsWithMatchOptions<T extends RequestOptionsWithMatc
 
 export abstract class AbstractRequestOptionsWithMatchOptions<T extends AbstractRequestOptionsWithMatchOptions<T>>
   extends AbstractRequestOptions<AbstractRequestOptionsWithMatchOptions<T>>
-  implements HasMatch<AbstractRequestOptionsWithMatchOptions<T>> {
+  implements RequestOptionsWithMatchOptions<AbstractRequestOptionsWithMatchOptions<T>> {
   public ifMatch(...tags: string[]): T {
     this.addHeader('If-Match', tags.join(', '));
     return this as unknown as T;

--- a/javascript/lib/api/tests/client/http/things.http.spec.ts
+++ b/javascript/lib/api/tests/client/http/things.http.spec.ts
@@ -15,7 +15,7 @@
 import { HttpThingsHandleV1, HttpThingsHandleV2 } from '../../../src/client/handles/things.interfaces';
 import { PutResponse } from '../../../src/model/response';
 import { Acl, AclEntry } from '../../../src/model/things.model';
-import { FieldsOptions, GetThingsOptions, MatchOptions } from '../../../src/options/request.options';
+import { DefaultFieldsOptions, DefaultGetThingsOptions, DefaultMatchOptions } from '../../../src/options/request.options';
 import { HttpHelper as H } from './http.helper';
 
 describe('Http Things Handle', () => {
@@ -30,7 +30,7 @@ describe('Http Things Handle', () => {
   const acl = new Acl({ [anAclEntry.id]: anAclEntry, [anotherAclEntry.id]: anotherAclEntry });
 
   it('sends options and gets a Thing', () => {
-    const options = FieldsOptions.getInstance().withFields('A', 'B').ifMatch('C').ifNoneMatch('D');
+    const options = DefaultFieldsOptions.getInstance().withFields('A', 'B').ifMatch('C').ifNoneMatch('D');
     const headers: Map<string, string> = new Map();
     headers.set('If-Match', 'C');
     headers.set('If-None-Match', 'D');
@@ -57,7 +57,7 @@ describe('Http Things Handle', () => {
   });
 
   it('gets Things with options', () => {
-    const options = GetThingsOptions.getInstance().withFields('A,B');
+    const options = DefaultGetThingsOptions.getInstance().withFields('A,B');
     return H.test({
       toTest: () => handleV2.getThings([H.thing.thingId], options),
       testBody: [H.thing.toObject()],
@@ -69,7 +69,7 @@ describe('Http Things Handle', () => {
   });
 
   it('sends empty options and gets a PolicyId', () => {
-    const options = MatchOptions.getInstance();
+    const options = DefaultMatchOptions.getInstance();
     return H.test({
       toTest: () => handleV2.getPolicyId(H.thing.thingId, options),
       testBody: 'ID',

--- a/javascript/lib/api/tests/client/websocket/things.websocket.spec.ts
+++ b/javascript/lib/api/tests/client/websocket/things.websocket.spec.ts
@@ -13,7 +13,7 @@
 
 /* tslint:disable:no-duplicate-string */
 import { PutResponse } from '../../../src/model/response';
-import { FieldsOptions } from '../../../src/options/request.options';
+import {  DefaultFieldsOptions } from '../../../src/options/request.options';
 import { WebSocketHelper, WebSocketHelper as H } from './websocket.helper';
 
 describe('WebSocket Things Handle', () => {
@@ -23,7 +23,7 @@ describe('WebSocket Things Handle', () => {
 
   it('retrieves a Thing', () => {
     return H.test({
-      toTest: () => handle.getThing(H.thing.thingId, FieldsOptions.getInstance().ifMatch('a')),
+      toTest: () => handle.getThing(H.thing.thingId, DefaultFieldsOptions.getInstance().ifMatch('a')),
       topic: `${baseTopic}/retrieve`,
       status: 200,
       requestHeaders: Object.assign(H.standardHeaders, { 'If-Match': 'a' }),

--- a/javascript/lib/api/tests/options/request.options.spec.ts
+++ b/javascript/lib/api/tests/options/request.options.spec.ts
@@ -16,11 +16,15 @@
 import { And, Eq, Ne, Not } from '../../src/options/filter.options';
 import {
   CountOptions,
+  DefaultCountOptions,
+  DefaultFieldsOptions,
+  DefaultGetThingsOptions,
+  DefaultMatchOptions,
+  DefaultMessagesOptions,
+  DefaultPostConnectionOptions,
+  DefaultSearchOptions,
   FieldsOptions,
-  GetThingsOptions,
   MatchOptions,
-  MessagesOptions,
-  PostConnectionOptions,
   SearchOptions
 } from '../../src/options/request.options';
 
@@ -29,7 +33,7 @@ describe('Match Options', () => {
   const noneMatch = 'If-None-Match';
   let matchOptions: MatchOptions;
   beforeEach(() => {
-    matchOptions = MatchOptions.getInstance();
+    matchOptions = DefaultMatchOptions.getInstance();
   });
   it('sets If-Match header', () => {
     matchOptions.ifMatch('A');
@@ -75,7 +79,7 @@ describe('Match Options', () => {
 describe('Get Options', () => {
   let getOptions: FieldsOptions;
   beforeEach(() => {
-    getOptions = FieldsOptions.getInstance();
+    getOptions = DefaultFieldsOptions.getInstance();
   });
   it('returns empty options', () => {
     expect(getOptions.getOptions().size).toEqual(0);
@@ -94,7 +98,7 @@ describe('Get Options', () => {
 describe('Count Options', () => {
   let countOptions: CountOptions;
   beforeEach(() => {
-    countOptions = CountOptions.getInstance();
+    countOptions = DefaultCountOptions.getInstance();
   });
   it('sets raw filter', () => {
     countOptions.withRawFilter('test');
@@ -143,7 +147,7 @@ describe('Count Options', () => {
 describe('Search Options', () => {
   let searchOptions: SearchOptions;
   beforeEach(() => {
-    searchOptions = SearchOptions.getInstance();
+    searchOptions = DefaultSearchOptions.getInstance();
   });
   it('sets fields', () => {
     searchOptions.withFields('A', 'B');
@@ -211,7 +215,7 @@ describe('Search Options', () => {
 });
 
 describe('Get Things Options', () => {
-  const getThingsOptions = GetThingsOptions.getInstance();
+  const getThingsOptions = DefaultGetThingsOptions.getInstance();
   it('sets fields', () => {
     getThingsOptions.withFields('A', 'B');
     expect(getThingsOptions.getOptions().get('fields')).toEqual(encodeURIComponent('A,B'));
@@ -224,7 +228,7 @@ describe('Get Things Options', () => {
 });
 
 describe('Messages Options', () => {
-  const messagesOptions = MessagesOptions.getInstance();
+  const messagesOptions = DefaultMessagesOptions.getInstance();
   it('sets timeout', () => {
     messagesOptions.withTimeout(1);
     expect(messagesOptions.getOptions().get('timeout')).toEqual('1');
@@ -236,7 +240,7 @@ describe('Messages Options', () => {
 });
 
 describe('Post Connection Options', () => {
-  const postConnectionOptions = PostConnectionOptions.getInstance();
+  const postConnectionOptions = DefaultPostConnectionOptions.getInstance();
   it('sets dry-run', () => {
     postConnectionOptions.asDryRun(false);
     expect(postConnectionOptions.getOptions().get('dry-run')).toEqual('false');


### PR DESCRIPTION
With the current interface, it is not possible to set all options supported by the API. The most prominent example is that you can only use LIMIT/OFFSET pagination for the search endpoint, while cursor-based pagination is advised by the API itself.

To make it easier to extend these options, this MR adds base interfaces for the `*Options` classes, renaming the existing classes to `Default*Options` (as opted by @ffendt ).

At Aloxy, we're also creating an SSE extension on top of this SDK, and we'd like to reuse these options as much as possible. 