### PR TITLE
Allow to respond to live messages via ditto client

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/live/messages/internal/ImmutableMessageSender.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/messages/internal/ImmutableMessageSender.java
@@ -145,10 +145,6 @@ public final class ImmutableMessageSender<T> implements MessageSender<T> {
                 .timestamp(messageTimestamp)
                 .correlationId(messageCorrelationId);
 
-        if (responseConsumer == null) {
-            messageHeadersBuilder.responseRequired(false);
-        }
-
         if (null != messageStatusCode) {
             if (messageStatusCode == HttpStatusCode.NO_CONTENT && payload != null) {
                 final String warnMessage = "StatusCode '" + HttpStatusCode.NO_CONTENT + "' cannot be used in "


### PR DESCRIPTION
Don't force response-required to be false when calling send() without response consumer.