### PR TITLE
Rework reconnect behaviour of java client

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingException.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingException.java
@@ -30,6 +30,8 @@ public class MessagingException extends RuntimeException {
     private static final String TIMEOUT_MESSAGE_TEMPLATE =
             "Connect of session <%s> failed because it timed out.";
 
+    private static final String RECREATE_FAILED_TEMPLATE = "Recreating WebSocket of session <%s> failed.";
+
     private static final long serialVersionUID = 6930767503633213674L;
 
     private MessagingException(final String message, final Throwable cause) {
@@ -46,6 +48,10 @@ public class MessagingException extends RuntimeException {
 
     public static MessagingException connectTimeout(final String sessionId, final Throwable cause) {
         return new MessagingException(String.format(TIMEOUT_MESSAGE_TEMPLATE, sessionId), cause);
+    }
+
+    public static MessagingException recreateFailed(final String sessionId, final Throwable cause) {
+        return new MessagingException(String.format(RECREATE_FAILED_TEMPLATE, sessionId), cause);
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/Retry.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/Retry.java
@@ -125,15 +125,17 @@ final class Retry<T> implements Supplier<CompletionStage<T>> {
          * @param sessionId the session ID of the client for which the action is performed.
          * @return the next builder step as a new instance.
          */
-        RetryBuilderFinal<T> inClientSession(String sessionId);
+        RetryBuilderStep2<T> inClientSession(String sessionId);
     }
 
+
     /**
-     * Final builder steps which are optionally required for the retry logic.
+     * Second step which requires the scheduled executor service to be configured. This executor service is used
+     * to schedule the supplier to be executed.
      *
      * @param <T> The return type of the supplier.
      */
-    interface RetryBuilderFinal<T> extends Supplier<CompletionStage<T>> {
+    interface RetryBuilderStep2<T> {
 
         /**
          * Specifies the executor to use when performing the action and its potential retries.
@@ -142,6 +144,14 @@ final class Retry<T> implements Supplier<CompletionStage<T>> {
          * @return a new instance of this builder step.
          */
         RetryBuilderFinal<T> withExecutor(final ScheduledExecutorService executorService);
+    }
+
+    /**
+     * Final builder steps which are optionally required for the retry logic.
+     *
+     * @param <T> The return type of the supplier.
+     */
+    interface RetryBuilderFinal<T> extends Supplier<CompletionStage<T>> {
 
         /**
          * Executes the provided supplier unit the supplier returns a result.
@@ -158,7 +168,7 @@ final class Retry<T> implements Supplier<CompletionStage<T>> {
      *
      * @param <T> the return type of the supplier.
      */
-    static class RetryBuilder<T> implements RetryBuilderStep1<T>, RetryBuilderFinal<T> {
+    static class RetryBuilder<T> implements RetryBuilderStep1<T>, RetryBuilderStep2<T>, RetryBuilderFinal<T> {
 
         private final String nameOfAction;
         private final Supplier<T> retriedSupplier;
@@ -181,7 +191,7 @@ final class Retry<T> implements Supplier<CompletionStage<T>> {
         }
 
         @Override
-        public RetryBuilderFinal<T> inClientSession(final String sessionId) {
+        public RetryBuilderStep2<T> inClientSession(final String sessionId) {
             return new RetryBuilder<>(nameOfAction, retriedSupplier, sessionId, executorService);
         }
 

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/Retry.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/Retry.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.client.messaging.internal;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides an easy way to implement a an action that should be retried.
+ * In this case this action must return a result which also can be null.
+ * As soon as a result is returned is by the supplier, the action is considered to be finished successfully.
+ *
+ * @param <T> Type of the result
+ */
+final class Retry<T> implements Supplier<CompletionStage<T>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Retry.class.getName());
+
+    private final String sessionId;
+    private final String nameOfAction;
+    private final Supplier<T> retriedSupplier;
+    private final Duration timeToWaitBeforeRetry;
+    private final ExecutorService executorService;
+
+
+    private Retry(final String nameOfAction,
+            final String sessionId,
+            final Supplier<T> retriedSupplier,
+            final Duration timeToWaitBeforeRetry,
+            final ExecutorService executorService) {
+
+        this.sessionId = sessionId;
+        this.nameOfAction = nameOfAction;
+        this.retriedSupplier = retriedSupplier;
+        this.timeToWaitBeforeRetry = timeToWaitBeforeRetry;
+        this.executorService = executorService;
+    }
+
+    /**
+     * Executes the provided supplier until a result is returned.
+     *
+     * @return A completion stage which finally completes with the result of the supplier. Result can be null.
+     */
+    @Override
+    public CompletionStage<T> get() {
+        return CompletableFuture.supplyAsync(this::doGet, executorService);
+    }
+
+    private T doGet() {
+        try {
+            return retriedSupplier.get();
+        } catch (final RuntimeException e) {
+            // log error, but try again (don't end loop)
+            LOGGER.error("Client <{}>: Failed to <{}>: {}.", sessionId, nameOfAction, e.getMessage());
+            waitFor(timeToWaitBeforeRetry);
+            return doGet();
+        }
+    }
+
+    private void waitFor(final Duration timeToWait) {
+        try {
+            LOGGER.info("Client <{}>: Waiting for <{}> seconds before retrying to <{}>.",
+                    sessionId, timeToWait.getSeconds(), nameOfAction);
+            TimeUnit.SECONDS.sleep(timeToWait.getSeconds());
+        } catch (final InterruptedException ie) {
+            LOGGER.error("Client <{}>: Interrupted while waiting for the next try to <{}>.",
+                    sessionId, nameOfAction, ie);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Creates a builder to configure the parameters that are relevant for the retry logic.
+     *
+     * @param nameOfAction A name of the action that is retried. This is only used for logging. E.g. "fetch services".
+     * @param supplierToRetry The action that should be retried until a result is returned. Result ca also be null.
+     * @param <T> The type of the expected result.
+     * @return The result of the supplier after it finally succeeds.
+     */
+    static <T> RetryBuilderStep1<T> retryTo(final String nameOfAction, Supplier<T> supplierToRetry) {
+        return new RetryBuilder<>(nameOfAction, supplierToRetry);
+    }
+
+    /**
+     * First step which required the client session to be configured. Even though this is just used for logging,
+     * this parameter is considered as mandatory, as it makes debugging and analyzing logs a lot easier.
+     *
+     * @param <T> The return type of the supplier.
+     */
+    interface RetryBuilderStep1<T> {
+
+        /**
+         * Configures the session ID that should be used for log statements made by performing the action and its
+         * potential retries.
+         *
+         * @param sessionId the session ID of the client for which the action is performed.
+         * @return the next builder step as a new instance.
+         */
+        RetryBuilderFinal<T> inClientSession(String sessionId);
+    }
+
+    /**
+     * Final builder steps which are optionally required for the retry logic.
+     *
+     * @param <T> The return type of the supplier.
+     */
+    interface RetryBuilderFinal<T> extends Supplier<CompletionStage<T>> {
+
+        /**
+         * Specifies the executor to use when performing the action and its potential retries.
+         *
+         * @param executorService the executor service.
+         * @return a new instance of this builder step.
+         */
+        RetryBuilderFinal<T> withExecutor(final ExecutorService executorService);
+
+        /**
+         * Specifies the time to wait before a retry should be performed.
+         *
+         * @param timeToWaitBeforeRetry the time to wait before a retry should be performed.
+         * @return a new instance of this builder step.
+         */
+        RetryBuilderFinal<T> andWaitBetweenRetriesFor(Duration timeToWaitBeforeRetry);
+
+        /**
+         * Executes the provided supplier unit the supplier returns a result.
+         *
+         * @return A completion stage which finally completes with the result of the supplier. Result can be null.
+         */
+        @Override
+        CompletionStage<T> get();
+
+    }
+
+    /**
+     * Builder to configure the retry logic.
+     *
+     * @param <T> the return type of the supplier.
+     */
+    static class RetryBuilder<T> implements RetryBuilderStep1<T>, RetryBuilderFinal<T> {
+
+        private static final Duration DEFAULT_TIME_TO_WAIT_BETWEEN_RETRIES = Duration.ofSeconds(1);
+
+        private final String nameOfAction;
+        private final Supplier<T> retriedSupplier;
+        private final String sessionId;
+        private final Duration timeToWaitBeforeRetry;
+        private final ExecutorService executorService;
+
+        private RetryBuilder(final String nameOfAction, final Supplier<T> retriedSupplier) {
+            this(nameOfAction, retriedSupplier, "", DEFAULT_TIME_TO_WAIT_BETWEEN_RETRIES, ForkJoinPool.commonPool());
+        }
+
+        private RetryBuilder(final String nameOfAction,
+                final Supplier<T> retriedSupplier,
+                final String sessionId,
+                final Duration timeToWaitBeforeRetry,
+                final ExecutorService executorService) {
+
+            this.nameOfAction = nameOfAction;
+            this.retriedSupplier = retriedSupplier;
+            this.sessionId = sessionId;
+            this.timeToWaitBeforeRetry = timeToWaitBeforeRetry;
+            this.executorService = executorService;
+        }
+
+        @Override
+        public RetryBuilderFinal<T> inClientSession(final String sessionId) {
+            return new RetryBuilder<>(nameOfAction, retriedSupplier, sessionId, timeToWaitBeforeRetry, executorService);
+        }
+
+        @Override
+        public RetryBuilderFinal<T> withExecutor(final ExecutorService executorService) {
+            return new RetryBuilder<>(nameOfAction, retriedSupplier, sessionId, timeToWaitBeforeRetry, executorService);
+        }
+
+        @Override
+        public RetryBuilderFinal<T> andWaitBetweenRetriesFor(final Duration timeToWaitBeforeRetry) {
+            return new RetryBuilder<>(nameOfAction, retriedSupplier, sessionId, timeToWaitBeforeRetry, executorService);
+        }
+
+
+        @Override
+        public CompletionStage<T> get() {
+            return new Retry<>(nameOfAction, sessionId, retriedSupplier, timeToWaitBeforeRetry, executorService).get();
+        }
+
+    }
+
+}

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
@@ -67,7 +66,6 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
     private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketMessagingProvider.class);
     private static final int CONNECTION_TIMEOUT_MS = 5000;
     private static final int RECONNECTION_TIMEOUT_SECONDS = 5;
-    private static final Duration TIME_BETWEEN_CONNECTION_TRIES = Duration.ofSeconds(1);
 
     private final AdaptableBus adaptableBus;
     private final MessagingConfiguration messagingConfiguration;
@@ -402,7 +400,6 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
                 .retryTo("initialize WebSocket connection", () -> initiateConnection(webSocket.get()))
                 .inClientSession(sessionId)
                 .withExecutor(executorService)
-                .andWaitBetweenRetriesFor(TIME_BETWEEN_CONNECTION_TRIES)
                 .get();
     }
 

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -175,11 +175,6 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
         } catch (final IOException e) {
             throw MessagingException.connectFailed(sessionId, e);
         }
-        // TODO: make these configurable?
-        ws.addHeader("User-Agent", DITTO_CLIENT_USER_AGENT);
-        ws.setMaxPayloadSize(256 * 1024); // 256 KiB
-        ws.setMissingCloseFrameAllowed(true);
-        ws.setFrameQueueSize(0);
         return ws;
     }
 
@@ -263,6 +258,12 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
     private WebSocket initiateConnection(final WebSocket ws) {
         checkNotNull(ws, "ws");
 
+        // TODO: make these configurable?
+        ws.addHeader("User-Agent", DITTO_CLIENT_USER_AGENT);
+        ws.setMaxPayloadSize(256 * 1024); // 256 KiB
+        ws.setMissingCloseFrameAllowed(true);
+        ws.setFrameQueueSize(0);
+        ws.setPingInterval(CONNECTION_TIMEOUT_MS);
         authenticationProvider.prepareAuthentication(ws);
         ws.addListener(this);
 

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
@@ -1,0 +1,59 @@
+package org.eclipse.ditto.client.messaging.internal;/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+public final class RetryTest {
+
+    @Test
+    public void getsResultOfRetryableSupplier() {
+        final Supplier<String> retryableSupplier = () -> "foo";
+        final String actualResult = Retry.retryTo("test the result", retryableSupplier)
+                .inClientSession(UUID.randomUUID().toString())
+                .get()
+                .toCompletableFuture()
+                .join();
+
+        assertThat(actualResult).isEqualTo("foo");
+    }
+
+    @Test
+    public void retriesSupplierIfFirstTryThrowsException() {
+        final CountDownLatch latch = new CountDownLatch(2);
+        final Supplier<String> retryableSupplier = () -> {
+            latch.countDown();
+            if (latch.getCount() == 1) {
+                throw new RuntimeException("Expected exception in first iteration.");
+            } else {
+                return "bar";
+            }
+        };
+        final String actualResult = Retry.retryTo("test the result", retryableSupplier)
+                .inClientSession(UUID.randomUUID().toString())
+                .get()
+                .toCompletableFuture()
+                .join();
+
+        assertThat(actualResult).isEqualTo("bar");
+        assertThat(latch.getCount()).isZero();
+    }
+
+}

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
@@ -14,20 +14,38 @@ package org.eclipse.ditto.client.messaging.internal;/*
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
+import org.eclipse.ditto.client.internal.DefaultThreadFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public final class RetryTest {
+
+    private static ScheduledExecutorService scheduledExecutorService;
+
+    @BeforeClass
+    public static void setup() {
+        scheduledExecutorService = Executors.newScheduledThreadPool(1, new DefaultThreadFactory("test"));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        scheduledExecutorService.shutdown();
+    }
+
 
     @Test
     public void getsResultOfRetryableSupplier() {
         final Supplier<String> retryableSupplier = () -> "foo";
         final String actualResult = Retry.retryTo("test the result", retryableSupplier)
                 .inClientSession(UUID.randomUUID().toString())
+                .withExecutor(scheduledExecutorService)
                 .get()
                 .toCompletableFuture()
                 .join();
@@ -48,6 +66,7 @@ public final class RetryTest {
         };
         final String actualResult = Retry.retryTo("test the result", retryableSupplier)
                 .inClientSession(UUID.randomUUID().toString())
+                .withExecutor(scheduledExecutorService)
                 .get()
                 .toCompletableFuture()
                 .join();


### PR DESCRIPTION
Note that I also added a ping timer for the websocket connection which allows us to be notified when there is a network interruption.

Without this ping, no reconnect would be triggered.