### PR TITLE
fixed missing OSGi import for "org.reactivestreams"

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -590,6 +590,7 @@
                             !org.eclipse.ditto.utils.jsr305.annotations,
                             org.eclipse.ditto.*,
                             org.slf4j.*,
+                            org.reactivestreams,
                             com.neovisionaries.ws.client
                         </Import-Package>
                         <_noee>true</_noee>


### PR DESCRIPTION
Dependency to "org.reactivestreams" was introduced in Ditto Java Client 1.1.0, however the OSGi import was missing.