### PR TITLE
Fix WebSocketMessagingProvider blocking forever on initialization when configured with an incorrect endpoint

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/internal/DefaultDittoClient.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/DefaultDittoClient.java
@@ -233,10 +233,16 @@ public final class DefaultDittoClient implements DittoClient {
     }
 
     private static void init(final PointerBus bus, final MessagingProvider messagingProvider) {
-        registerKeyBasedDistributorForIncomingEvents(bus);
-        registerKeyBasedHandlersForIncomingEvents(bus, messagingProvider,
-                DittoProtocolAdapter.of(HeaderTranslator.empty()));
-        messagingProvider.initialize();
+        try {
+            registerKeyBasedDistributorForIncomingEvents(bus);
+            registerKeyBasedHandlersForIncomingEvents(bus, messagingProvider,
+                    DittoProtocolAdapter.of(HeaderTranslator.empty()));
+            messagingProvider.initialize();
+        } catch (final RuntimeException e) {
+            bus.close();
+            messagingProvider.close();
+            throw e;
+        }
     }
 
     private static void registerKeyBasedDistributorForIncomingEvents(final PointerBus bus) {
@@ -549,5 +555,4 @@ public final class DefaultDittoClient implements DittoClient {
                         emitAcknowledgement)
         );
     }
-
 }

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultPointerBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultPointerBus.java
@@ -59,7 +59,7 @@ final class DefaultPointerBus implements PointerBus {
     @Override
     public void close() {
         consumerRegistry.clear();
-        executor.shutdown();
+        executor.shutdownNow();
         try {
             executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (final InterruptedException e) {

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -453,8 +453,8 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
      * @see this#mapConnectError(Throwable)
      */
     private static boolean isRecoverable(final Throwable error) {
-        return !(error instanceof AuthenticationException ||
-                error instanceof MessagingException && error.getCause() instanceof UnknownHostException);
+        // every exception should be recoverable
+        return true;
     }
 
 }

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
@@ -15,6 +15,8 @@ package org.eclipse.ditto.client.messaging.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -42,7 +44,7 @@ public final class RetryTest {
 
     @Test
     public void getsResultOfRetryableSupplier() {
-        final Supplier<String> retryableSupplier = () -> "foo";
+        final Supplier<CompletionStage<String>> retryableSupplier = () -> CompletableFuture.completedFuture("foo");
         final String actualResult = Retry.retryTo("test the result", retryableSupplier)
                 .inClientSession(UUID.randomUUID().toString())
                 .withExecutor(scheduledExecutorService)
@@ -56,14 +58,14 @@ public final class RetryTest {
     @Test
     public void retriesSupplierIfFirstTryThrowsException() {
         final CountDownLatch latch = new CountDownLatch(2);
-        final Supplier<String> retryableSupplier = () -> {
+        final Supplier<CompletionStage<String>> retryableSupplier = () -> CompletableFuture.supplyAsync(() -> {
             latch.countDown();
             if (latch.getCount() == 1) {
                 throw new RuntimeException("Expected exception in first iteration.");
             } else {
                 return "bar";
             }
-        };
+        });
         final String actualResult = Retry.retryTo("test the result", retryableSupplier)
                 .inClientSession(UUID.randomUUID().toString())
                 .withExecutor(scheduledExecutorService)
@@ -80,14 +82,14 @@ public final class RetryTest {
         final int numberOfRetries = 2;
         final CountDownLatch errorConsumerLatch = new CountDownLatch(numberOfRetries);
         final CountDownLatch totalTriesLatch = new CountDownLatch(numberOfRetries + 1);
-        final Supplier<String> retryableSupplier = () -> {
+        final Supplier<CompletionStage<String>> retryableSupplier = () -> CompletableFuture.supplyAsync(() -> {
             totalTriesLatch.countDown();
             if (totalTriesLatch.getCount() > 0) {
                 throw new RuntimeException("Expected exception in first iteration.");
             } else {
                 return "bar";
             }
-        };
+        });
         final String actualResult = Retry.retryTo("test the result", retryableSupplier)
                 .inClientSession(UUID.randomUUID().toString())
                 .withExecutor(scheduledExecutorService)

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 public final class RetryTest {
 
+    private static final Supplier<Boolean> IS_CANCELLED = () -> false;
     private static ScheduledExecutorService scheduledExecutorService;
 
     @BeforeClass
@@ -45,7 +46,7 @@ public final class RetryTest {
     @Test
     public void getsResultOfRetryableSupplier() {
         final Supplier<CompletionStage<String>> retryableSupplier = () -> CompletableFuture.completedFuture("foo");
-        final String actualResult = Retry.retryTo("test the result", retryableSupplier)
+        final String actualResult = Retry.retryTo("test the result", retryableSupplier, IS_CANCELLED)
                 .inClientSession(UUID.randomUUID().toString())
                 .withExecutor(scheduledExecutorService)
                 .get()
@@ -66,7 +67,7 @@ public final class RetryTest {
                 return "bar";
             }
         });
-        final String actualResult = Retry.retryTo("test the result", retryableSupplier)
+        final String actualResult = Retry.retryTo("test the result", retryableSupplier, IS_CANCELLED)
                 .inClientSession(UUID.randomUUID().toString())
                 .withExecutor(scheduledExecutorService)
                 .get()
@@ -90,7 +91,7 @@ public final class RetryTest {
                 return "bar";
             }
         });
-        final String actualResult = Retry.retryTo("test the result", retryableSupplier)
+        final String actualResult = Retry.retryTo("test the result", retryableSupplier, IS_CANCELLED)
                 .inClientSession(UUID.randomUUID().toString())
                 .withExecutor(scheduledExecutorService)
                 .notifyOnError(error -> {

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
@@ -13,24 +13,34 @@
 package org.eclipse.ditto.client.messaging.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.UnknownHostException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import org.eclipse.ditto.client.configuration.BasicAuthenticationConfiguration;
 import org.eclipse.ditto.client.configuration.MessagingConfiguration;
 import org.eclipse.ditto.client.configuration.WebSocketMessagingConfiguration;
+import org.eclipse.ditto.client.messaging.AuthenticationException;
 import org.eclipse.ditto.client.messaging.AuthenticationProvider;
 import org.eclipse.ditto.client.messaging.AuthenticationProviders;
+import org.eclipse.ditto.client.messaging.MessagingException;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.junit.AfterClass;
 import org.junit.Test;
 
+import com.neovisionaries.ws.client.OpeningHandshakeException;
 import com.neovisionaries.ws.client.WebSocket;
 
 /**
@@ -38,42 +48,131 @@ import com.neovisionaries.ws.client.WebSocket;
  */
 public final class WebSocketMessagingProviderTest {
 
-    @Test(timeout = 5000)
-    public void connectToPort0() throws Exception {
+    private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+
+    @AfterClass
+    public static void shutdownExecutor() {
+        EXECUTOR.shutdownNow();
+    }
+
+    @Test
+    public void connectToUnknownHost() throws Exception {
+        final BlockingQueue<Throwable> errors = new LinkedBlockingQueue<>();
+        final WebSocketMessagingProvider underTest =
+                WebSocketMessagingProvider.newInstance(configOf("ws://unknown.host.invalid:80", errors::add),
+                        dummyAuth(), EXECUTOR);
+
+        // WHEN: websocket connect to a nonsense address
+        // THEN: the calling thread receives a CompletionException
+        assertThatExceptionOfType(CompletionException.class).isThrownBy(underTest::initialize);
+
+        // THEN: the error handler is notified exactly once
+        assertThat(errors.take())
+                .isInstanceOf(MessagingException.class)
+                .hasCauseInstanceOf(UnknownHostException.class);
+        expectNoMsg(errors);
+    }
+
+    @Test
+    public void forbidden() throws Exception {
         final BlockingQueue<ServerSocket> serverSocket = new LinkedBlockingQueue<>();
         CompletableFuture.runAsync(() -> {
             try (final ServerSocket s = new ServerSocket(0)) {
                 serverSocket.add(s);
-                final Socket ss = s.accept();
-                ss.close();
+                writeAndClose(s.accept(), "HTTP/1.0 403 Forbidden");
             } catch (final Exception e) {
                 throw new RuntimeException(e);
             }
         });
-        final ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
-        final MessagingConfiguration config = WebSocketMessagingConfiguration.newBuilder()
-                .jsonSchemaVersion(JsonSchemaVersion.V_2)
-                .reconnectEnabled(true)
-                .endpoint("ws://127.0.0.1:" + serverSocket.take().getLocalPort())
-                .connectionErrorHandler(errors::add)
-                .reconnectEnabled(true)
-                .build();
-        final AuthenticationProvider<WebSocket> auth = AuthenticationProviders.basic(
-                BasicAuthenticationConfiguration.newBuilder()
-                        .username("username")
-                        .password("password")
-                        .build()
-        );
-        final ExecutorService callbackExecutor = Executors.newSingleThreadExecutor();
+        final BlockingQueue<Throwable> errors = new LinkedBlockingQueue<>();
+        final MessagingConfiguration config =
+                configOf("ws://127.0.0.1:" + serverSocket.take().getLocalPort(), errors::add);
         final WebSocketMessagingProvider underTest =
-                WebSocketMessagingProvider.newInstance(config, auth, callbackExecutor);
+                WebSocketMessagingProvider.newInstance(config, dummyAuth(), EXECUTOR);
 
-        // WHEN: websocket connect to a nonsense address
-        // THEN: the calling thread should not block nor throw any exception
-        underTest.initialize();
+        // WHEN: websocket connect to a forbidden address
+        // THEN: the calling thread receives a CompletionException
+        assertThatExceptionOfType(CompletionException.class).isThrownBy(underTest::initialize);
 
         // THEN: the error handler is notified exactly once
-        Thread.sleep(2500L);
-        assertThat(errors.size()).isEqualTo(1L);
+        assertThat(errors.take()).isInstanceOf(AuthenticationException.class);
+        expectNoMsg(errors);
+    }
+
+    @Test(timeout = 10_000)
+    public void serviceUnavailable() throws Exception {
+        final int numberOfRecoverableErrors = 3;
+        final BlockingQueue<ServerSocket> serverSocket = new LinkedBlockingQueue<>();
+        CompletableFuture.runAsync(() -> {
+            try (final ServerSocket s = new ServerSocket(0)) {
+                serverSocket.add(s);
+                for (int i = 0; i < numberOfRecoverableErrors; ++i) {
+                    writeAndClose(s.accept(), "HTTP/1.0 503 Server hurt itself in its confusion!");
+                }
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        final BlockingQueue<Throwable> errors = new LinkedBlockingQueue<>();
+        final MessagingConfiguration config =
+                configOf("ws://127.0.0.1:" + serverSocket.take().getLocalPort(), errors::add);
+        final WebSocketMessagingProvider underTest =
+                WebSocketMessagingProvider.newInstance(config, dummyAuth(), EXECUTOR);
+
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            // WHEN: websocket connect to an unavailable address
+            final CompletableFuture<?> future = CompletableFuture.runAsync(underTest::initialize, executor);
+
+            // THEN: the error handler is notified many times
+            for (int i = 0; i < numberOfRecoverableErrors; ++i) {
+                assertThat(errors.take())
+                        .isInstanceOf(MessagingException.class)
+                        .hasCauseInstanceOf(OpeningHandshakeException.class);
+            }
+
+            // THEN: the calling thread of .initialize blocks until the client is destroyed,
+            // upon which an exception is thrown
+            underTest.close();
+            assertThatExceptionOfType(CompletionException.class)
+                    .isThrownBy(future::join)
+                    .withCauseInstanceOf(MessagingException.class);
+        } finally {
+            // NOT a hard kill
+            executor.shutdownNow();
+        }
+    }
+
+    private MessagingConfiguration configOf(final String uri, final Consumer<Throwable> errorHandler) {
+        return WebSocketMessagingConfiguration.newBuilder()
+                .jsonSchemaVersion(JsonSchemaVersion.V_2)
+                .reconnectEnabled(true)
+                .endpoint(uri)
+                .connectionErrorHandler(errorHandler)
+                .reconnectEnabled(true)
+                .build();
+    }
+
+    private AuthenticationProvider<WebSocket> dummyAuth() {
+        return AuthenticationProviders.basic(
+                BasicAuthenticationConfiguration.newBuilder().username("dummy").password("auth").build());
+    }
+
+    private static void writeAndClose(final Socket socket, final String line) throws Exception {
+        final PrintWriter writer = new PrintWriter(socket.getOutputStream());
+        writer.println(line);
+        writer.println();
+        writer.flush();
+        socket.close();
+    }
+
+    private static void expectNoMsg(final BlockingQueue<?> queue) {
+        try {
+            assertThat(queue.poll(2500, TimeUnit.MILLISECONDS))
+                    .describedAs("Expect no more notifications, but got one.")
+                    .isNull();
+        } catch (final Exception e) {
+            throw new AssertionError(e);
+        }
     }
 }

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.client.messaging.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -79,7 +78,7 @@ public final class WebSocketMessagingProviderTest {
         CompletableFuture.runAsync(() -> {
             try (final ServerSocket s = new ServerSocket(0)) {
                 serverSocket.add(s);
-                writeAndClose(s.accept(), "HTTP/1.0 403 Forbidden");
+                write(s.accept(), "HTTP/1.0 403 Forbidden");
             } catch (final Exception e) {
                 throw new RuntimeException(e);
             }
@@ -107,7 +106,7 @@ public final class WebSocketMessagingProviderTest {
             try (final ServerSocket s = new ServerSocket(0)) {
                 serverSocket.add(s);
                 for (int i = 0; i < numberOfRecoverableErrors; ++i) {
-                    writeAndClose(s.accept(), "HTTP/1.0 503 Server hurt itself in its confusion!");
+                    write(s.accept(), "HTTP/1.0 503 Server hurt itself in its confusion!");
                 }
             } catch (final Exception e) {
                 throw new RuntimeException(e);
@@ -158,12 +157,11 @@ public final class WebSocketMessagingProviderTest {
                 BasicAuthenticationConfiguration.newBuilder().username("dummy").password("auth").build());
     }
 
-    private static void writeAndClose(final Socket socket, final String line) throws Exception {
+    private static void write(final Socket socket, final String line) throws Exception {
         final PrintWriter writer = new PrintWriter(socket.getOutputStream());
         writer.println(line);
         writer.println();
         writer.flush();
-        socket.close();
     }
 
     private static void expectNoMsg(final BlockingQueue<?> queue) {

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.client.messaging.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.eclipse.ditto.client.configuration.BasicAuthenticationConfiguration;
+import org.eclipse.ditto.client.configuration.MessagingConfiguration;
+import org.eclipse.ditto.client.configuration.WebSocketMessagingConfiguration;
+import org.eclipse.ditto.client.messaging.AuthenticationProvider;
+import org.eclipse.ditto.client.messaging.AuthenticationProviders;
+import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.junit.Test;
+
+import com.neovisionaries.ws.client.WebSocket;
+
+/**
+ * Tests the error handling behavior of websocket messaging provider.
+ */
+public final class WebSocketMessagingProviderTest {
+
+    @Test(timeout = 5000)
+    public void connectToPort0() throws Exception {
+        final BlockingQueue<ServerSocket> serverSocket = new LinkedBlockingQueue<>();
+        CompletableFuture.runAsync(() -> {
+            try (final ServerSocket s = new ServerSocket(0)) {
+                serverSocket.add(s);
+                final Socket ss = s.accept();
+                ss.close();
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        final ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+        final MessagingConfiguration config = WebSocketMessagingConfiguration.newBuilder()
+                .jsonSchemaVersion(JsonSchemaVersion.V_2)
+                .reconnectEnabled(true)
+                .endpoint("ws://127.0.0.1:" + serverSocket.take().getLocalPort())
+                .connectionErrorHandler(errors::add)
+                .reconnectEnabled(true)
+                .build();
+        final AuthenticationProvider<WebSocket> auth = AuthenticationProviders.basic(
+                BasicAuthenticationConfiguration.newBuilder()
+                        .username("username")
+                        .password("password")
+                        .build()
+        );
+        final ExecutorService callbackExecutor = Executors.newSingleThreadExecutor();
+        final WebSocketMessagingProvider underTest =
+                WebSocketMessagingProvider.newInstance(config, auth, callbackExecutor);
+
+        // WHEN: websocket connect to a nonsense address
+        // THEN: the calling thread should not block nor throw any exception
+        underTest.initialize();
+
+        // THEN: the error handler is notified exactly once
+        Thread.sleep(2500L);
+        assertThat(errors.size()).isEqualTo(1L);
+    }
+}

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.eclipse.ditto.client.configuration.BasicAuthenticationConfiguration;
@@ -55,11 +56,45 @@ public final class WebSocketMessagingProviderTest {
     }
 
     @Test
-    public void connectToUnknownHost() throws Exception {
+    public void connectToUnknownHost() {
         final BlockingQueue<Throwable> errors = new LinkedBlockingQueue<>();
         final WebSocketMessagingProvider underTest =
                 WebSocketMessagingProvider.newInstance(configOf("ws://unknown.host.invalid:80", errors::add),
                         dummyAuth(), EXECUTOR);
+        final CompletableFuture<?> future = CompletableFuture.runAsync(() -> {
+            try {
+                // timeout should be greater than the first two timeouts of Retry#TIME_TO_WAIT_BETWEEN_RETRIES_IN_SECONDS
+                TimeUnit.SECONDS.sleep(3);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            underTest.close();
+        });
+
+        // WHEN: websocket connect to a nonsense address
+        // THEN: the calling thread receives a CompletionException
+        assertThatExceptionOfType(CompletionException.class).isThrownBy(underTest::initialize);
+        assertThat(future).isCompleted();
+
+        // THEN: the error handler is notified multiple times
+        assertThat(errors).hasSizeGreaterThan(1);
+        errors.forEach(error -> assertThat(error)
+                .isInstanceOf(MessagingException.class)
+                .hasCauseInstanceOf(UnknownHostException.class));
+    }
+
+    @Test
+    public void connectToUnknownHostWithErrorConsumer() throws Exception {
+        final BlockingQueue<Throwable> errors = new LinkedBlockingQueue<>();
+        final AtomicReference<WebSocketMessagingProvider> messagingProviderReference = new AtomicReference<>();
+        final ExecutorService e = Executors.newSingleThreadExecutor();
+        final WebSocketMessagingProvider underTest =
+                WebSocketMessagingProvider.newInstance(configOf("ws://unknown.host.invalid:80", error -> {
+                            messagingProviderReference.get().close();
+                            errors.add(error);
+                        }),
+                        dummyAuth(), e);
+        messagingProviderReference.set(underTest);
 
         // WHEN: websocket connect to a nonsense address
         // THEN: the calling thread receives a CompletionException
@@ -89,13 +124,29 @@ public final class WebSocketMessagingProviderTest {
         final WebSocketMessagingProvider underTest =
                 WebSocketMessagingProvider.newInstance(config, dummyAuth(), EXECUTOR);
 
+        final CompletableFuture<?> future = CompletableFuture.runAsync(() -> {
+            try {
+                // timeout should be greater than the first two timeouts of Retry#TIME_TO_WAIT_BETWEEN_RETRIES_IN_SECONDS
+                TimeUnit.SECONDS.sleep(3);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            underTest.close();
+        });
         // WHEN: websocket connect to a forbidden address
         // THEN: the calling thread receives a CompletionException
         assertThatExceptionOfType(CompletionException.class).isThrownBy(underTest::initialize);
+        assertThat(future).isCompleted();
 
-        // THEN: the error handler is notified exactly once
-        assertThat(errors.take()).isInstanceOf(AuthenticationException.class);
-        expectNoMsg(errors);
+        // THEN: the error handler is notified multiple times
+        assertThat(errors).hasSizeGreaterThan(1);
+        while (errors.size() > 1) {
+            assertThat(errors.take())
+                    .isInstanceOf(AuthenticationException.class);
+        }
+        // THEN: the last error is a MessagingException because of closing the provider manually in our future.
+        assertThat(errors.take())
+                .isInstanceOf(MessagingException.class);
     }
 
     @Test(timeout = 10_000)
@@ -173,4 +224,5 @@ public final class WebSocketMessagingProviderTest {
             throw new AssertionError(e);
         }
     }
+
 }


### PR DESCRIPTION
- Fix some redundant executor creation and racing.
- Do not reconnect after encountering an unrecoverable error. Unrecoverable errors are UnknownHostException and 4xx status codes from server.
- If WebsocketMessagingProvider is closed by another thread during client creation, then the client creation will throw an exception. In contrast, the previous behavior would block the calling thread forever.

Related: #65 