### PR TITLE
Add possibility to enable/disable inital connection retries

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/configuration/MessagingConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/MessagingConfiguration.java
@@ -55,6 +55,13 @@ public interface MessagingConfiguration {
     boolean isReconnectEnabled();
 
     /**
+     * @return {@code true} if client should retry when connection initialization failed.
+     *
+     * @since 1.3.0
+     */
+    boolean isInitialConnectRetryEnabled();
+
+    /**
      * Returns the proxy configuration.
      *
      * @return the configuration or an empty optional.
@@ -116,6 +123,17 @@ public interface MessagingConfiguration {
          * @return this builder.
          */
         Builder reconnectEnabled(boolean reconnectEnabled);
+
+        /**
+         * Sets if {@code initialConnectRetryEnbaled}.
+         * <p> Default is disabled. When establishing a new connection, the client doesn't try to reconnect.
+         *
+         * @param initialConnectRetryEnabled enables/disables retrying connection initialization.
+         * @return this builder.
+         *
+         * @since 1.3.0
+         */
+        Builder initialConnectRetryEnabled(boolean initialConnectRetryEnabled);
 
         /**
          * Sets the {@code proxyConfiguration}.

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/WebSocketMessagingConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/WebSocketMessagingConfiguration.java
@@ -40,6 +40,7 @@ public final class WebSocketMessagingConfiguration implements MessagingConfigura
     private final JsonSchemaVersion jsonSchemaVersion;
     private final URI endpointUri;
     private final boolean reconnectEnabled;
+    private final boolean initialConnectRetryEnabled;
     @Nullable private final ProxyConfiguration proxyConfiguration;
     @Nullable private final TrustStoreConfiguration trustStoreConfiguration;
     @Nullable private final Consumer<Throwable> connectionErrorHandler;
@@ -49,6 +50,7 @@ public final class WebSocketMessagingConfiguration implements MessagingConfigura
 
         jsonSchemaVersion = builder.jsonSchemaVersion;
         reconnectEnabled = builder.reconnectEnabled;
+        initialConnectRetryEnabled = builder.initialConnectRetryEnabled;
         proxyConfiguration = builder.proxyConfiguration;
         trustStoreConfiguration = builder.trustStoreConfiguration;
         connectionErrorHandler = builder.connectionErrorHandler;
@@ -81,6 +83,11 @@ public final class WebSocketMessagingConfiguration implements MessagingConfigura
     }
 
     @Override
+    public boolean isInitialConnectRetryEnabled() {
+        return initialConnectRetryEnabled;
+    }
+
+    @Override
     public Optional<ProxyConfiguration> getProxyConfiguration() {
         return Optional.ofNullable(proxyConfiguration);
     }
@@ -105,6 +112,7 @@ public final class WebSocketMessagingConfiguration implements MessagingConfigura
         private Duration timeout = Duration.ofSeconds(60L);
         private URI endpointUri;
         private boolean reconnectEnabled;
+        private boolean initialConnectRetryEnabled;
         @Nullable private ProxyConfiguration proxyConfiguration;
         private TrustStoreConfiguration trustStoreConfiguration;
         @Nullable private Consumer<Throwable> connectionErrorHandler;
@@ -112,6 +120,7 @@ public final class WebSocketMessagingConfiguration implements MessagingConfigura
         private WebSocketMessagingConfigurationBuilder() {
             jsonSchemaVersion = JsonSchemaVersion.LATEST;
             reconnectEnabled = true;
+            initialConnectRetryEnabled = false;
             proxyConfiguration = null;
             connectionErrorHandler = null;
         }
@@ -144,6 +153,12 @@ public final class WebSocketMessagingConfiguration implements MessagingConfigura
         @Override
         public MessagingConfiguration.Builder reconnectEnabled(final boolean reconnectEnabled) {
             this.reconnectEnabled = reconnectEnabled;
+            return this;
+        }
+
+        @Override
+        public MessagingConfiguration.Builder initialConnectRetryEnabled(final boolean initialConnectRetryEnabled) {
+            this.initialConnectRetryEnabled = initialConnectRetryEnabled;
             return this;
         }
 

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/MockMessagingProvider.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/MockMessagingProvider.java
@@ -157,6 +157,7 @@ public class MockMessagingProvider implements MessagingProvider {
         return WebSocketMessagingConfiguration.newBuilder()
                 .endpoint("ws://localhost:8080")
                 .jsonSchemaVersion(version)
+                .initialConnectRetryEnabled(true)
                 .build();
     }
 

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
@@ -130,6 +130,7 @@ public final class WebSocketMessagingProviderTest {
                 .endpoint(uri)
                 .connectionErrorHandler(errorHandler)
                 .reconnectEnabled(true)
+                .initialConnectRetryEnabled(true)
                 .build();
     }
 


### PR DESCRIPTION
This allows to configure the client to do retries when initially connecting and changes the default behavior for connection initialization to don't use retries.

Signed-off-by: David Schwilk <david.schwilk@bosch.io>