### PR TITLE
Issue #87: Prevent leakage of AdaptableBus threads after closing the client

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/DisconnectedDittoClient.java
+++ b/java/src/main/java/org/eclipse/ditto/client/DisconnectedDittoClient.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.client;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Client interface before connecting.
+ */
+public interface DisconnectedDittoClient {
+
+    /**
+     * Connect the client to the configured Ditto back-end.
+     * If this method is called more than once, the result is not defined.
+     *
+     * @return a future that completes with the connected client.
+     */
+    CompletionStage<DittoClient> connect();
+
+    /**
+     * Release resources held by this client.
+     */
+    void destroy();
+}

--- a/java/src/main/java/org/eclipse/ditto/client/DisconnectedDittoClient.java
+++ b/java/src/main/java/org/eclipse/ditto/client/DisconnectedDittoClient.java
@@ -16,6 +16,8 @@ import java.util.concurrent.CompletionStage;
 
 /**
  * Client interface before connecting.
+ *
+ * @since 1.3.0
  */
 public interface DisconnectedDittoClient {
 

--- a/java/src/main/java/org/eclipse/ditto/client/DittoClients.java
+++ b/java/src/main/java/org/eclipse/ditto/client/DittoClients.java
@@ -137,7 +137,7 @@ public final class DittoClients {
 
     /**
      * Creates a new {@link org.eclipse.ditto.client.DittoClient} with a shared {@code Twin} and {@code Live}
-     * {@link org.eclipse.ditto.client.messaging.MessagingProvider} but do not attempt to connect to the configured
+     * {@link org.eclipse.ditto.client.messaging.MessagingProvider} but does not attempt to connect to the configured
      * back-end.
      *
      * @param messagingProvider the messaging provider for this client.
@@ -151,8 +151,8 @@ public final class DittoClients {
 
     /**
      * Creates a new {@link org.eclipse.ditto.client.DittoClient} with a specific {@code Twin}, {@code Live} and
-     * {@code Policy} {@link org.eclipse.ditto.client.messaging.MessagingProvider} but do not attempt to the configured
-     * back-end.
+     * {@code Policy} {@link org.eclipse.ditto.client.messaging.MessagingProvider} but does not attempt to connect to
+     * the configured back-end.
      *
      * @param twinMessagingProvider the messaging provider for the {@code Twin} part of the client.
      * @param liveMessagingProvider the messaging provider for the {@code Live} part of the client.

--- a/java/src/main/java/org/eclipse/ditto/client/DittoClients.java
+++ b/java/src/main/java/org/eclipse/ditto/client/DittoClients.java
@@ -135,4 +135,40 @@ public final class DittoClients {
                 messageSerializerRegistry);
     }
 
+    /**
+     * Creates a new {@link org.eclipse.ditto.client.DittoClient} with a shared {@code Twin} and {@code Live}
+     * {@link org.eclipse.ditto.client.messaging.MessagingProvider} but do not attempt to connect to the configured
+     * back-end.
+     *
+     * @param messagingProvider the messaging provider for this client.
+     * @return the disconnected client.
+     * @since 1.3.0
+     */
+    public static DisconnectedDittoClient newDisconnectedInstance(final MessagingProvider messagingProvider) {
+        return newDisconnectedInstance(messagingProvider, messagingProvider, messagingProvider,
+                MessageSerializerFactory.newInstance().getMessageSerializerRegistry());
+    }
+
+    /**
+     * Creates a new {@link org.eclipse.ditto.client.DittoClient} with a specific {@code Twin}, {@code Live} and
+     * {@code Policy} {@link org.eclipse.ditto.client.messaging.MessagingProvider} but do not attempt to the configured
+     * back-end.
+     *
+     * @param twinMessagingProvider the messaging provider for the {@code Twin} part of the client.
+     * @param liveMessagingProvider the messaging provider for the {@code Live} part of the client.
+     * @param policyMessagingProvider the messaging provider for the {@code Policy} part of the client.
+     * @param messageSerializerRegistry a registry of {@code MessageSerializer}s for the {@code Live} part of the client.
+     * @return the disconnected client.
+     * @since 1.3.0
+     */
+    public static DisconnectedDittoClient newDisconnectedInstance(final MessagingProvider twinMessagingProvider,
+            final MessagingProvider liveMessagingProvider, final MessagingProvider policyMessagingProvider,
+            final MessageSerializerRegistry messageSerializerRegistry) {
+
+        return DefaultDittoClient.newDisconnectedInstance(twinMessagingProvider,
+                liveMessagingProvider,
+                policyMessagingProvider,
+                messageSerializerRegistry);
+    }
+
 }

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
@@ -110,6 +110,13 @@ public interface AdaptableBus {
     boolean unsubscribe(@Nullable SubscriptionId subscriptionId);
 
     /**
+     * Closes the executor of the adaptable bus .
+     *
+     * @since 1.2.2
+     */
+    void shutdownExecutor();
+
+    /**
      * Publish a string message that may or may not be an adaptable.
      *
      * @param message the string message.

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
@@ -111,8 +111,6 @@ public interface AdaptableBus {
 
     /**
      * Closes the executor of the adaptable bus .
-     *
-     * @since 1.2.2
      */
     void shutdownExecutor();
 

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
@@ -141,6 +141,12 @@ final class DefaultAdaptableBus implements AdaptableBus {
         singleThreadedExecutorService.submit(() -> doPublish(message));
     }
 
+    @Override
+    public void shutdownExecutor() {
+        LOGGER.trace("Shutting down AdaptableBus Executor");
+        singleThreadedExecutorService.shutdownNow();
+    }
+
     // call this in a single-threaded executor so that ordering is preserved
     private void doPublish(final String message) {
         if (publishToOneTimeStringSubscribers(message)) {

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
@@ -143,8 +143,9 @@ final class DefaultAdaptableBus implements AdaptableBus {
 
     @Override
     public void shutdownExecutor() {
-        LOGGER.trace("Shutting down AdaptableBus Executor");
+        LOGGER.trace("Shutting down AdaptableBus Executors");
         singleThreadedExecutorService.shutdownNow();
+        scheduledExecutorService.shutdownNow();
     }
 
     // call this in a single-threaded executor so that ordering is preserved

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProvider.java
@@ -42,7 +42,7 @@ public interface MessagingProvider {
     /**
      * Initializes the Messaging Provider by opening the underlying connections, etc.
      * Blocks the calling thread until messaging provider is ready.
-     * Use {@code initializeAsync} instead.
+     * @deprecated since 1.3.0. Use {@code initializeAsync} instead.
      */
     @Deprecated
     default void initialize() {
@@ -52,7 +52,7 @@ public interface MessagingProvider {
     /**
      * Perform initialization asynchronously.
      *
-     * @return a future that completes after initialization completes.
+     * @return a future that completes after initialization completed.
      * @since 1.3.0
      */
     CompletionStage<?> initializeAsync();

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProvider.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
@@ -41,8 +42,20 @@ public interface MessagingProvider {
     /**
      * Initializes the Messaging Provider by opening the underlying connections, etc.
      * Blocks the calling thread until messaging provider is ready.
+     * Use {@code initializeAsync} instead.
      */
-    void initialize();
+    @Deprecated
+    default void initialize() {
+        initializeAsync().toCompletableFuture().join();
+    }
+
+    /**
+     * Perform initialization asynchronously.
+     *
+     * @return a future that completes after initialization completes.
+     * @since 1.3.0
+     */
+    CompletionStage<?> initializeAsync();
 
     /**
      * Returns the {@code AuthenticationConfiguration} of this provider.

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -74,11 +74,11 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
     private final AuthenticationProvider<WebSocket> authenticationProvider;
     private final ExecutorService callbackExecutor;
     private final String sessionId;
-    private final ScheduledExecutorService reconnectExecutor;
+    private final ScheduledExecutorService connectExecutor;
     private final Map<Object, String> subscriptionMessages;
     private final AtomicBoolean reconnecting = new AtomicBoolean(false);
-    private final AtomicBoolean initiallyConnected = new AtomicBoolean(false);
-    private final AtomicBoolean isCancelled = new AtomicBoolean(false);
+    private final AtomicBoolean initializing = new AtomicBoolean(false);
+    private final CompletableFuture<WebSocket> initializationFuture = new CompletableFuture<>();
 
     private final AtomicReference<WebSocket> webSocket;
 
@@ -100,12 +100,12 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
         this.callbackExecutor = callbackExecutor;
 
         sessionId = authenticationProvider.getConfiguration().getSessionId();
-        reconnectExecutor = createReconnectExecutor();
+        connectExecutor = createConnectExecutor();
         subscriptionMessages = new ConcurrentHashMap<>();
         webSocket = new AtomicReference<>();
     }
 
-    private static ScheduledExecutorService createReconnectExecutor() {
+    private static ScheduledExecutorService createConnectExecutor() {
         return Executors.newScheduledThreadPool(1, new DefaultThreadFactory("ditto-client-reconnect"));
     }
 
@@ -144,6 +144,15 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
         return callbackExecutor;
     }
 
+    /**
+     * Return the executor for reconnection.
+     *
+     * @return the reconnect executor.
+     */
+    public ScheduledExecutorService getConnectExecutor() {
+        return connectExecutor;
+    }
+
     @Override
     public AdaptableBus getAdaptableBus() {
         return adaptableBus;
@@ -162,23 +171,19 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
     }
 
     @Override
-    public synchronized void initialize() {
+    public CompletionStage<?> initializeAsync() {
         // this method may be called multiple times.
-        synchronized (initiallyConnected) {
+        if (!initializing.getAndSet(true)) {
             if (webSocket.get() == null) {
-                final ScheduledExecutorService executor = createConnectionExecutor();
-                try {
-                    setWebSocket(
-                            connectWithPotentialRetries(this::createWebsocket, executor).toCompletableFuture().join());
-                    initiallyConnected.set(true);
-                } catch (CompletionException e) {
-                    LOGGER.error("Encountered error during initial connection.");
-                    throw e;
-                } finally {
-                    executor.shutdownNow();
-                }
+                return connectWithPotentialRetries(this::createWebsocket, initializationFuture)
+                        .thenApply(ws -> {
+                            setWebSocket(ws);
+                            return this;
+                        });
             }
         }
+        // no need to set flags for subsequent calls of this method
+        return initializationFuture.thenApply(ws -> this);
     }
 
     private WebSocket createWebsocket() {
@@ -201,9 +206,8 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
      * be empty.
      * @throws NullPointerException if any argument is {@code null}.
      */
-    private CompletionStage<WebSocket> initiateConnection(final WebSocket ws, final ExecutorService executor) {
+    private CompletionStage<WebSocket> initiateConnection(final WebSocket ws) {
         checkNotNull(ws, "ws");
-        checkNotNull(executor, "executor");
 
         // TODO: make these configurable?
         ws.addHeader("User-Agent", DITTO_CLIENT_USER_AGENT);
@@ -215,20 +219,14 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
         ws.addListener(this);
 
         LOGGER.info("Connecting WebSocket on endpoint <{}>.", ws.getURI());
-        final CompletableFuture<WebSocket> webSocketFuture = new CompletableFuture<>();
         final Callable<WebSocket> connectCallable = ws.connectable();
-        executor.submit(() -> {
+        return CompletableFuture.supplyAsync(() -> {
             try {
-                webSocketFuture.complete(connectCallable.call());
+                return connectCallable.call();
             } catch (final Throwable e) {
-                webSocketFuture.completeExceptionally(mapConnectError(e));
+                throw mapConnectError(e);
             }
-        });
-        return webSocketFuture;
-    }
-
-    private static ScheduledExecutorService createConnectionExecutor() {
-        return Executors.newScheduledThreadPool(1, new DefaultThreadFactory("ditto-client-connect"));
+        }, connectExecutor);
     }
 
     @Override
@@ -249,25 +247,26 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
 
     @Override
     public void close() {
-        synchronized (isCancelled) {
-            if (!isCancelled.get()) {
-                try {
-                    LOGGER.debug("Client <{}>: Closing WebSocket client of endpoint <{}>.", sessionId,
-                            messagingConfiguration.getEndpointUri());
+        try {
+            LOGGER.debug("Client <{}>: Closing WebSocket client of endpoint <{}>.", sessionId,
+                    messagingConfiguration.getEndpointUri());
 
-                    cancelScheduledReconnect();
-                    authenticationProvider.destroy();
-                    adaptableBus.shutdownExecutor();
-                    final WebSocket ws = webSocket.get();
-                    if (ws != null) {
-                        ws.disconnect();
-                    }
-
-                    LOGGER.info("Client <{}>: WebSocket destroyed.", sessionId);
-                } catch (final Exception e) {
-                    LOGGER.info("Client <{}>: Exception occurred while trying to shutdown http client.", sessionId, e);
-                }
+            // Scheduled tasks obtained from "shutdownNow" are useless because they overrides Runnable.run()
+            // to NOT run when the parent executor was shut down.
+            connectExecutor.shutdownNow();
+            authenticationProvider.destroy();
+            adaptableBus.shutdownExecutor();
+            final WebSocket ws = webSocket.get();
+            if (ws != null) {
+                ws.disconnect();
             }
+
+            LOGGER.info("Client <{}>: WebSocket destroyed.", sessionId);
+            initializationFuture.completeExceptionally(MessagingException.connectFailed(sessionId,
+                    new IllegalStateException("The client was destroyed.")));
+        } catch (final Exception e) {
+            LOGGER.info("Client <{}>: Exception occurred while trying to shutdown http client.", sessionId, e);
+            initializationFuture.completeExceptionally(MessagingException.connectFailed(sessionId, e));
         }
     }
 
@@ -276,15 +275,13 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
         callbackExecutor.execute(() -> {
             LOGGER.info("Client <{}>: WebSocket connection is established", sessionId);
 
-            if (initiallyConnected.get()) {
-                // we were already connected - so this is a reconnect
+            if (!subscriptionMessages.isEmpty()) {
                 LOGGER.info("Client <{}>: Subscribing again for messages from backend after reconnection",
                         sessionId);
                 subscriptionMessages.values().forEach(this::emit);
             }
         });
     }
-
 
     @Override
     public void onDisconnected(final WebSocket websocket, final WebSocketFrame serverCloseFrame,
@@ -321,20 +318,32 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
         });
     }
 
-    private CompletionStage<WebSocket> connectWithPotentialRetries(final Supplier<WebSocket> webSocket,
-            final ScheduledExecutorService executorService) {
+    private CompletableFuture<WebSocket> connectWithPotentialRetries(final Supplier<WebSocket> webSocket,
+            final CompletableFuture<WebSocket> future) {
 
-        if (messagingConfiguration.isInitialConnectRetryEnabled()) {
-            return Retry.retryTo("initialize WebSocket connection",
-                    () -> initiateConnection(webSocket.get(), reconnectExecutor), isCancelled::get)
-                    .inClientSession(sessionId)
-                    .withExecutor(executorService)
-                    .notifyOnError(messagingConfiguration.getConnectionErrorHandler().orElse(null))
-                    .isRecoverable(WebSocketMessagingProvider::isRecoverable)
-                    .get();
-        } else {
-            LOGGER.info("Client <{}>: Initializing WebSocket connection without retrying", sessionId);
-            return initiateConnection(webSocket.get(), executorService);
+        try {
+            if (messagingConfiguration.isInitialConnectRetryEnabled()) {
+                return Retry.retryTo("initialize WebSocket connection",
+                        () -> initiateConnection(webSocket.get()))
+                        .inClientSession(sessionId)
+                        .withExecutors(connectExecutor, callbackExecutor)
+                        .notifyOnError(messagingConfiguration.getConnectionErrorHandler().orElse(null))
+                        .isRecoverable(WebSocketMessagingProvider::isRecoverable)
+                        .completeFutureEventually(future);
+            } else {
+                LOGGER.info("Client <{}>: Initializing WebSocket connection without retrying", sessionId);
+                initiateConnection(webSocket.get()).whenComplete((result, error) -> {
+                    if (error == null) {
+                        future.complete(result);
+                    } else {
+                        future.completeExceptionally(error);
+                    }
+                });
+                return future;
+            }
+        } catch (final Exception exception) {
+            future.completeExceptionally(exception);
+            return future;
         }
     }
 
@@ -342,10 +351,10 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
 
         if (messagingConfiguration.isReconnectEnabled()) {
             // reconnect in a while if client was initially connected and we are not reconnecting already
-            if (initiallyConnected.get() && reconnecting.compareAndSet(false, true) && null != reconnectExecutor) {
+            if (reconnecting.compareAndSet(false, true)) {
                 LOGGER.info("Client <{}>: Reconnection is enabled. Reconnecting in <{}> seconds ...",
                         sessionId, RECONNECTION_TIMEOUT_SECONDS);
-                reconnectExecutor.schedule(this::reconnectWithRetries, RECONNECTION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                connectExecutor.schedule(this::reconnectWithRetries, RECONNECTION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             }
         } else {
             LOGGER.info("Client <{}>: Reconnection is NOT enabled. Closing client ...", sessionId);
@@ -354,7 +363,7 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
     }
 
     private void reconnectWithRetries() {
-        this.connectWithPotentialRetries(this::recreateWebSocket, reconnectExecutor)
+        this.connectWithPotentialRetries(this::recreateWebSocket, new CompletableFuture<>())
                 .thenAccept(reconnectedWebSocket -> {
                     setWebSocket(reconnectedWebSocket);
                     reconnecting.set(false);
@@ -415,19 +424,8 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
         adaptableBus.publish(message);
     }
 
-    private void cancelScheduledReconnect() {
-        isCancelled.set(true);
-        if (null != reconnectExecutor) {
-            // Run the Retry tasks on the reconnect executor here
-            // so that they release any threads waiting on them, because isCancelled(true)
-            reconnectExecutor.shutdownNow().forEach(Runnable::run);
-        }
-    }
-
-    private Throwable mapConnectError(final Throwable e) {
-        final Throwable cause = (e instanceof CompletionException || e instanceof ExecutionException)
-                ? e.getCause()
-                : e;
+    private RuntimeException mapConnectError(final Throwable e) {
+        final Throwable cause = getRootCause(e);
         if (cause instanceof WebSocketException) {
             LOGGER.error("Got exception: {}", cause.getMessage());
             if (cause instanceof OpeningHandshakeException) {
@@ -465,6 +463,15 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
     private static boolean isRecoverable(final Throwable error) {
         // every exception should be recoverable
         return true;
+    }
+
+    private static Throwable getRootCause(final Throwable e) {
+        if (e.getCause() == null) {
+            return e;
+        }
+        return (e instanceof CompletionException || e instanceof ExecutionException)
+                ? getRootCause(e.getCause())
+                : e;
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -253,6 +253,7 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
 
                     cancelScheduledReconnect();
                     authenticationProvider.destroy();
+                    adaptableBus.shutdownExecutor();
                     final WebSocket ws = webSocket.get();
                     if (ws != null) {
                         ws.disconnect();

--- a/java/src/test/java/org/eclipse/ditto/client/DittoClientUsageExamples.java
+++ b/java/src/test/java/org/eclipse/ditto/client/DittoClientUsageExamples.java
@@ -691,7 +691,12 @@ public final class DittoClientUsageExamples {
         }
     }
 
-    private static MessagingProvider createMessagingProvider() {
+    /**
+     * Create a messaging provider according to the configuration.
+     *
+     * @return the messaging provider.
+     */
+    public static MessagingProvider createMessagingProvider() {
         final MessagingConfiguration.Builder builder = WebSocketMessagingConfiguration.newBuilder()
                 .endpoint(DITTO_ENDPOINT_URL)
                 .jsonSchemaVersion(JsonSchemaVersion.V_2)

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/MockMessagingProvider.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/MockMessagingProvider.java
@@ -15,6 +15,8 @@ package org.eclipse.ditto.client.messaging.internal;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -108,8 +110,8 @@ public class MockMessagingProvider implements MessagingProvider {
     }
 
     @Override
-    public void initialize() {
-        // noop
+    public CompletionStage<?> initializeAsync() {
+        return CompletableFuture.completedFuture(this);
     }
 
     @Override

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/RetryTest.java
@@ -46,11 +46,10 @@ public final class RetryTest {
     @Test
     public void getsResultOfRetryableSupplier() {
         final Supplier<CompletionStage<String>> retryableSupplier = () -> CompletableFuture.completedFuture("foo");
-        final String actualResult = Retry.retryTo("test the result", retryableSupplier, IS_CANCELLED)
+        final String actualResult = Retry.retryTo("test the result", retryableSupplier)
                 .inClientSession(UUID.randomUUID().toString())
-                .withExecutor(scheduledExecutorService)
-                .get()
-                .toCompletableFuture()
+                .withExecutors(scheduledExecutorService, scheduledExecutorService)
+                .completeFutureEventually(new CompletableFuture<>())
                 .join();
 
         assertThat(actualResult).isEqualTo("foo");
@@ -67,11 +66,10 @@ public final class RetryTest {
                 return "bar";
             }
         });
-        final String actualResult = Retry.retryTo("test the result", retryableSupplier, IS_CANCELLED)
+        final String actualResult = Retry.retryTo("test the result", retryableSupplier)
                 .inClientSession(UUID.randomUUID().toString())
-                .withExecutor(scheduledExecutorService)
-                .get()
-                .toCompletableFuture()
+                .withExecutors(scheduledExecutorService, scheduledExecutorService)
+                .completeFutureEventually(new CompletableFuture<>())
                 .join();
 
         assertThat(actualResult).isEqualTo("bar");
@@ -91,16 +89,15 @@ public final class RetryTest {
                 return "bar";
             }
         });
-        final String actualResult = Retry.retryTo("test the result", retryableSupplier, IS_CANCELLED)
+        final String actualResult = Retry.retryTo("test the result", retryableSupplier)
                 .inClientSession(UUID.randomUUID().toString())
-                .withExecutor(scheduledExecutorService)
+                .withExecutors(scheduledExecutorService, scheduledExecutorService)
                 .notifyOnError(error -> {
                     assertThat(error).isInstanceOf(RuntimeException.class);
                     assertThat(error.getMessage()).isEqualTo("Expected exception in first iteration.");
                     errorConsumerLatch.countDown();
                 })
-                .get()
-                .toCompletableFuture()
+                .completeFutureEventually(new CompletableFuture<>())
                 .join();
 
         assertThat(actualResult).isEqualTo("bar");

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
@@ -22,6 +22,7 @@ import java.net.UnknownHostException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -32,7 +33,6 @@ import java.util.function.Consumer;
 import org.eclipse.ditto.client.configuration.BasicAuthenticationConfiguration;
 import org.eclipse.ditto.client.configuration.MessagingConfiguration;
 import org.eclipse.ditto.client.configuration.WebSocketMessagingConfiguration;
-import org.eclipse.ditto.client.messaging.AuthenticationException;
 import org.eclipse.ditto.client.messaging.AuthenticationProvider;
 import org.eclipse.ditto.client.messaging.AuthenticationProviders;
 import org.eclipse.ditto.client.messaging.MessagingException;
@@ -73,7 +73,7 @@ public final class WebSocketMessagingProviderTest {
         assertThatExceptionOfType(CompletionException.class).isThrownBy(underTest::initialize);
 
         // THEN: the error handler is notified exactly once
-        assertThat(errors.take())
+        assertThat(errors.poll(2L, TimeUnit.SECONDS))
                 .isInstanceOf(MessagingException.class)
                 .hasCauseInstanceOf(UnknownHostException.class);
         expectNoMsg(errors);
@@ -99,38 +99,31 @@ public final class WebSocketMessagingProviderTest {
         final WebSocketMessagingProvider underTest =
                 WebSocketMessagingProvider.newInstance(config, dummyAuth(), EXECUTOR);
 
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
-        try {
-            // WHEN: websocket connect to an unavailable address
-            final CompletableFuture<?> future = CompletableFuture.runAsync(underTest::initialize, executor);
+        // WHEN: websocket connect to an unavailable address
+        final CompletableFuture<?> future = underTest.initializeAsync().toCompletableFuture();
 
-            // THEN: the error handler is notified many times
-            for (int i = 0; i < numberOfRecoverableErrors; ++i) {
-                assertThat(errors.take())
-                        .isInstanceOf(MessagingException.class)
-                        .hasCauseInstanceOf(OpeningHandshakeException.class);
-            }
-
-            // THEN: the calling thread of .initialize blocks until the client is destroyed,
-            // upon which an exception is thrown
-            underTest.close();
-            assertThatExceptionOfType(CompletionException.class)
-                    .isThrownBy(future::join)
-                    .withCauseInstanceOf(MessagingException.class);
-        } finally {
-            // NOT a hard kill
-            executor.shutdownNow();
+        // THEN: the error handler is notified many times
+        for (int i = 0; i < numberOfRecoverableErrors; ++i) {
+            assertThat(errors.poll(2L, TimeUnit.SECONDS))
+                    .isInstanceOf(MessagingException.class)
+                    .hasCauseInstanceOf(OpeningHandshakeException.class);
         }
+
+        // THEN: the calling thread of .initialize blocks until the client is destroyed,
+        // upon which an exception is thrown
+        underTest.close();
+        assertThatExceptionOfType(ExecutionException.class)
+                .isThrownBy(() -> future.get(5L, TimeUnit.SECONDS))
+                .withCauseInstanceOf(MessagingException.class);
     }
 
     private MessagingConfiguration configOf(final String uri, final Consumer<Throwable> errorHandler) {
         return WebSocketMessagingConfiguration.newBuilder()
                 .jsonSchemaVersion(JsonSchemaVersion.V_2)
                 .reconnectEnabled(true)
+                .initialConnectRetryEnabled(true)
                 .endpoint(uri)
                 .connectionErrorHandler(errorHandler)
-                .reconnectEnabled(true)
-                .initialConnectRetryEnabled(true)
                 .build();
     }
 


### PR DESCRIPTION
Until now the MessagingProvider was closed when the client was destroyed. The executor of the MessagingProvider's AdaptableBus was left open and caused blocked threads after destruction of the client.

This fixes this behavior by closing the AdaptableBus executor when closing the MessagingProvider.

Signed-off-by: David Schwilk <david.schwilk@bosch.io>

Fixes #87 