### PR TITLE
Fix reordering of messages

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -396,20 +396,15 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
 
     @Override
     public void onBinaryMessage(final WebSocket websocket, final byte[] binary) {
-        callbackExecutor.execute(() -> {
-            final String stringMessage = new String(binary, StandardCharsets.UTF_8);
-            LOGGER.debug(
-                    "Client <{}>: Received WebSocket byte array message <{}>, as string <{}> - don't know what to do" +
-                            " with it!.", sessionId, binary, stringMessage);
-        });
+        final String stringMessage = new String(binary, StandardCharsets.UTF_8);
+        LOGGER.debug("Client <{}>: Received WebSocket byte array message <{}>, as string <{}> - don't know what to do" +
+                " with it!.", sessionId, binary, stringMessage);
     }
 
     @Override
     public void onTextMessage(final WebSocket websocket, final String text) {
-        callbackExecutor.execute(() -> {
-            LOGGER.debug("Client <{}>: Received WebSocket string message <{}>", sessionId, text);
-            handleIncomingMessage(text);
-        });
+        LOGGER.debug("Client <{}>: Received WebSocket string message <{}>", sessionId, text);
+        handleIncomingMessage(text);
     }
 
     private void handleIncomingMessage(final String message) {


### PR DESCRIPTION
Do not run `WebSocketMessagingProvider.onTextMessage` and `.onBinaryMessage`
on the callback executor. Run them in the reader thread directly.
The adaptable bus already checks whether a message requires a single-
threaded executor or can be handled in a thread pool.