### PR TITLE
Fix FeatureChange consumation for specific feature change-registration

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/SelectorUtil.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/SelectorUtil.java
@@ -172,11 +172,7 @@ public final class SelectorUtil {
                     if (value.isObject()) {
                         final List<JsonPointer> pointersOnLevel = new ArrayList<>();
                         final JsonObject objectOnLevel = value.asObject();
-                        if (objectOnLevel.getSize() > 1) {
-                            // if more than one sub-fields are contained in the object on this level, we add the "parent"
-                            // aggregating both of the changed fields:
                             pointersOnLevel.add(pointerOnLevel);
-                        }
 
                         // recurse further "down":
                         pointersOnLevel.addAll(calculateJsonPointerHierarchy(pointerOnLevel, objectOnLevel));


### PR DESCRIPTION
This fixes a bug that caused ignoring features in a FeatureChange for change-registrations on single features, when only a single subpath exists in the feature. (i.e. feature with only properties)

This fixes the issue by including all sub-paths of features in the FeatureChange to the pointer hierarchy, which is used to distribute changes to different registrations.

Signed-off-by: David Schwilk <david.schwilk@bosch.io>