### PR TITLE
Bugfix/complete start consumption future

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
@@ -13,6 +13,8 @@
 package org.eclipse.ditto.client.internal.bus;
 
 import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
@@ -52,6 +54,14 @@ public interface AdaptableBus {
      * @return this object.
      */
     AdaptableBus addAdaptableClassifier(Classifier<Adaptable> adaptableClassifier);
+
+
+    /**
+     * Get oneTimeStringConsumers but unmodifiable to only grant read access.
+     *
+     * @return a {@code UnmodifiableMap}
+     */
+    Map<Classification, Set<Entry<Consumer<String>>>> getUnmodifiableOneTimeStringConsumers();
 
     /**
      * Add a one-time subscriber for a string message.

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import org.eclipse.ditto.protocoladapter.Adaptable;
 
 /**
- * Event bus for messages that are either {@code String} or {@code} Adaptable.
+ * Event bus for messages that are either {@code String} or {@code Adaptable}.
  * On publication of a message as {@code String}, subscribers are notified as follows:
  * <ol>
  * <li>Message is classified as {@code String}. If a matching one-time subscriber is found, the subscriber is notified

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
@@ -90,7 +90,6 @@ final class DefaultAdaptableBus implements AdaptableBus {
         return Collections.unmodifiableMap(oneTimeStringConsumers);
     }
 
-
     @Override
     public CompletionStage<String> subscribeOnceForString(final Classification tag, final Duration timeout) {
         return subscribeOnce(oneTimeStringConsumers, tag, timeout);

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/Entry.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/Entry.java
@@ -1,0 +1,24 @@
+package org.eclipse.ditto.client.internal.bus;
+
+/**
+ * Similar to Map.Entry but with object reference identity and fixed key type to act as identifier for
+ * a subscription.
+ */
+final class Entry<T> implements AdaptableBus.SubscriptionId {
+
+    private final Classification key;
+    private final T value;
+
+    public Entry(final Classification key, final T value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public Classification getKey() {
+        return key;
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/Entry.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/Entry.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.ditto.client.internal.bus;
 
 /**

--- a/java/src/main/java/org/eclipse/ditto/client/twin/internal/UncompletedConsumptionRequestException.java
+++ b/java/src/main/java/org/eclipse/ditto/client/twin/internal/UncompletedConsumptionRequestException.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.ditto.client.twin.internal;
 
-public class UncompletedTwinConsumptionRequestException extends RuntimeException {
+public class UncompletedConsumptionRequestException extends RuntimeException {
 
     private static final long serialVersionUID = -565137801315595348L;
     private static final String MESSAGE = "First consumption request on this channel must be completed first";
@@ -20,7 +20,7 @@ public class UncompletedTwinConsumptionRequestException extends RuntimeException
     /**
      * Constructs a new {@code UncompletedTwinConsumptionRequestException} object.
      */
-    public UncompletedTwinConsumptionRequestException() {
+    public UncompletedConsumptionRequestException() {
         super(MESSAGE, null);
     }
 

--- a/java/src/main/java/org/eclipse/ditto/client/twin/internal/UncompletedTwinConsumptionRequestException.java
+++ b/java/src/main/java/org/eclipse/ditto/client/twin/internal/UncompletedTwinConsumptionRequestException.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.ditto.client.twin.internal;
 
 public class UncompletedTwinConsumptionRequestException extends RuntimeException {

--- a/java/src/main/java/org/eclipse/ditto/client/twin/internal/UncompletedTwinConsumptionRequestException.java
+++ b/java/src/main/java/org/eclipse/ditto/client/twin/internal/UncompletedTwinConsumptionRequestException.java
@@ -1,0 +1,15 @@
+package org.eclipse.ditto.client.twin.internal;
+
+public class UncompletedTwinConsumptionRequestException extends RuntimeException {
+
+    private static final long serialVersionUID = -565137801315595348L;
+    private static final String MESSAGE = "First consumption request on this channel must be completed first";
+
+    /**
+     * Constructs a new {@code UncompletedTwinConsumptionRequestException} object.
+     */
+    public UncompletedTwinConsumptionRequestException() {
+        super(MESSAGE, null);
+    }
+
+}

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/MockMessagingProvider.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/MockMessagingProvider.java
@@ -150,6 +150,10 @@ public class MockMessagingProvider implements MessagingProvider {
         adaptableBus.publish(ProtocolFactory.wrapAsJsonifiableAdaptable(adaptable).toJsonString());
     }
 
+    public void receivePlainString(final String plain) {
+        adaptableBus.publish(plain);
+    }
+
     @Override
     public void close() {
         executor.shutdownNow();


### PR DESCRIPTION
Fix if startConsumption started in parallel and is not waiting for completion. Is fixed for Twin and Live Channel