### PR TITLE
Add possibility to set custom api path

### DIFF
--- a/javascript/lib/api/README.md
+++ b/javascript/lib/api/README.md
@@ -20,7 +20,7 @@ Basically it makes sense to trigger the build process once from
 the [parent module](../../README.md). Then you'll be able to
 use the default build process in here:
 
-```
+```shell
 npm install
 npm run build
 npm run lint
@@ -36,20 +36,20 @@ the variable `client` to be an instance of `ThingsClient` for the following usag
 explanations.
 
 The client provides different handles to handle requests for specific parts of the Things API:
-```
+```typescript
 const thingsHandle = client.getThingsHandle();
 ```
 
 The handles' methods will send requests and return their responses asynchronously.
 For example the code to update a Thing would look like this:
-```
+```typescript
 const thing = new Thing('the:thing');
 thingsHandle.putThing(thing)
     .then(result => console.log(`Finished putting thing with result: ${JSON.stringify(result)}`));
 ```
 
 Additionally options for requests can be specified and passed on to the methods:
-```
+```typescript
 const options = DefaultFieldsOptions.getInstance();
 options.ifMatch('A Tag').withFields('thingId', 'policyId', '_modified');
 thingsHandle.getThing('Testthing:TestId', options)
@@ -64,10 +64,12 @@ Each implementation will provide an HTTP implementation of the `ThingsClient` an
 will use HTTP requests to communicate with Eclipse Ditto. The builder for the
 client will guide you through the following steps.
 
-```
+```typescript
 client = builder
   // You can decide whether the client will use a TLS (https) connection or not:
   .withTls() // or .withoutTls()
+  // Optional step if path to the api is not simply /api 
+  //.withCustomPath('/custom/path/to/api')
   // which domain the client will connect to
   .withDomain('localhost:8080')
   // Which auth provider to use. E.g. for basic auth there are different versions
@@ -84,7 +86,7 @@ Similar to the HTTP Client, each implementation will provide an WebSocket implem
 of the `ThingsClient` that will use a WebSocket connection to communicate with
 Eclipse Ditto. The builder for the client will guide you through the following steps.
 
-```
+```typescript
 client = builder
   // You can decide whether the client will use a TLS (https) connection or not:
   .withTls() // or .withoutTls()
@@ -107,7 +109,7 @@ client = builder
 ### Errors
 There are a few error responses that are not defined within the Eclipse Ditto API. These mainly relate to problems
 with the web socket connection.
-```
+```json5
 {
   status: 0,
   error: 'connection.unavailable',
@@ -117,7 +119,7 @@ with the web socket connection.
 ```
 This error is returned when the buffer is turned off and the WebSocket connection is not currently established.
 A connection is still being attempted.
-```
+```json5
 {
   status: 1,
   error: 'connection.interrupted',
@@ -127,7 +129,7 @@ A connection is still being attempted.
 ```
 This error is returned when the WebSocket connection failed while a request was waiting for it's response.
 It's not possible to tell whether the request was received by the service or not.
-```
+```json5
 {
   status: 2,
   error: 'connection.lost',
@@ -137,7 +139,7 @@ It's not possible to tell whether the request was received by the service or not
 ```
 This error is returned when the connection to the service could not be established/reestablished.
 Any future requests will return the same error.
-```
+```json5
 {
   status: 3,
   error: 'buffer.overflow',

--- a/javascript/lib/api/src/client/builder-steps.ts
+++ b/javascript/lib/api/src/client/builder-steps.ts
@@ -68,6 +68,14 @@ interface ProtocolStep<T extends BuildStep, U extends BuildStep> extends BuildSt
  * @param <U> - type of API 2 Build steps.
  */
 interface EnvironmentStep<T extends BuildStep, U extends BuildStep> extends BuildStep {
+
+  /**
+   * Sets a custom path for the api endpoint (optional step)
+   *
+   * @param path custom ditto api path, e.g. /custom - will be used instead of the default /api
+   */
+  withCustomPath(path: string): EnvironmentStep<T, U>;
+
   /**
    * Sets a custom domain to use for requests.
    *
@@ -212,6 +220,7 @@ interface CustomSearchHandleStep<R, H extends SearchHandle> extends BuildStep {
 abstract class AbstractBuilder<T extends BuildStep, U extends BuildStep> implements ProtocolStep<T, U>, EnvironmentStep<T, U>,
   AuthenticationStep<T, U>, ApiVersionStep<T, U> {
   protected domain!: string;
+  protected customPath?: string;
   protected apiVersion!: ApiVersion;
   protected authProviders!: AuthProvider[];
   protected tls!: boolean;
@@ -224,6 +233,11 @@ abstract class AbstractBuilder<T extends BuildStep, U extends BuildStep> impleme
 
   withoutTls(): EnvironmentStep<T, U> {
     this.tls = false;
+    return this;
+  }
+
+  withCustomPath(path: string): EnvironmentStep<T, U> {
+    this.customPath = path;
     return this;
   }
 

--- a/javascript/lib/api/src/client/http-client-builder.ts
+++ b/javascript/lib/api/src/client/http-client-builder.ts
@@ -13,7 +13,13 @@
 
 import { HttpThingsHandle, HttpThingsHandleV1, HttpThingsHandleV2 } from './handles/things.interfaces';
 import { HttpRequester, HttpRequestSenderBuilder } from './request-factory/http-request-sender';
-import { AllDittoHttpHandles, DefaultDittoHttpClient, DittoHttpClient, DittoHttpClientV1, DittoHttpClientV2 } from './ditto-client-http';
+import {
+  AllDittoHttpHandles,
+  DefaultDittoHttpClient,
+  DittoHttpClient,
+  DittoHttpClientV1,
+  DittoHttpClientV2
+} from './ditto-client-http';
 import { HttpMessagesHandle } from './handles/messages-http';
 import { PoliciesHandle } from './handles/policies';
 import { SearchHandle } from './handles/search';
@@ -122,7 +128,8 @@ export class HttpClientBuilder extends AbstractBuilder<BuildStepApi1, BuildStepA
 
   private buildUrl(): DittoURL {
     const protocol = this.tls ? 'https' : 'http';
-    return ImmutableURL.newInstance(protocol, this.domain, `/api/${this.apiVersion}`);
+    const path = this.customPath === undefined ? this.customPath : '/api';
+    return ImmutableURL.newInstance(protocol, this.domain, `${path}/${this.apiVersion}`);
   }
 
   withCustomThingsHandle(factory: (requestSenderBuilder: HttpRequestSenderBuilder,

--- a/javascript/lib/api/src/client/http-client-builder.ts
+++ b/javascript/lib/api/src/client/http-client-builder.ts
@@ -128,7 +128,7 @@ export class HttpClientBuilder extends AbstractBuilder<BuildStepApi1, BuildStepA
 
   private buildUrl(): DittoURL {
     const protocol = this.tls ? 'https' : 'http';
-    const path = this.customPath === undefined ? this.customPath : '/api';
+    const path = (this.customPath === undefined) ? '/api' : this.customPath;
     return ImmutableURL.newInstance(protocol, this.domain, `${path}/${this.apiVersion}`);
   }
 

--- a/javascript/lib/api/src/client/websocket-client-builder.ts
+++ b/javascript/lib/api/src/client/websocket-client-builder.ts
@@ -189,9 +189,11 @@ export class WebSocketClientBuilder extends AbstractBuilder<WebSocketBufferStep,
 
   build(): DefaultDittoWebSocketClient {
     const protocol = this.tls ? 'wss' : 'ws';
+    const path = this.customPath === undefined ? this.customPath : '/ws';
+
     const resilienceHandlerFactory = this.resilienceFactory.withContext(
       this.builder.withConnectionDetails(
-        ImmutableURL.newInstance(protocol, this.domain, `/ws/${this.apiVersion}`),
+        ImmutableURL.newInstance(protocol, this.domain, `${path}/${this.apiVersion}`),
         this.authProviders),
       this.stateHandler);
     const requester = new WebSocketRequestHandler(resilienceHandlerFactory);

--- a/javascript/lib/api/src/client/websocket-client-builder.ts
+++ b/javascript/lib/api/src/client/websocket-client-builder.ts
@@ -189,7 +189,7 @@ export class WebSocketClientBuilder extends AbstractBuilder<WebSocketBufferStep,
 
   build(): DefaultDittoWebSocketClient {
     const protocol = this.tls ? 'wss' : 'ws';
-    const path = this.customPath === undefined ? this.customPath : '/ws';
+    const path = (this.customPath === undefined) ? '/ws' : this.customPath;
 
     const resilienceHandlerFactory = this.resilienceFactory.withContext(
       this.builder.withConnectionDetails(

--- a/javascript/lib/api/tests/client/http/http-client-builder.spec.ts
+++ b/javascript/lib/api/tests/client/http/http-client-builder.spec.ts
@@ -25,20 +25,25 @@ class DummyAuthProvider implements AuthProvider {
   constructor(private readonly username: string, private readonly password: string) {
 
   }
+
   authenticateWithHeaders(originalHeaders: DittoHeaders): DittoHeaders {
     return originalHeaders;
   }
+
   authenticateWithUrl(originalUrl: DittoURL): DittoURL {
     return originalUrl;
   }
 
 }
+
 const dummyAuthProvider1: AuthProvider = new DummyAuthProvider('a', 'b');
 const dummyAuthProvider2: AuthProvider = new DummyAuthProvider('a', 'b');
 const dummyAuthProviders: AuthProvider[] = [dummyAuthProvider1, dummyAuthProvider2];
 const expectedUrl = ImmutableURL.newInstance('https', 'eclipse.ditto.org', '/api/2');
+const expectedCustomUrl = ImmutableURL.newInstance('https', 'eclipse.ditto.org', '/secure-api/2');
 const requester = new TestRequester('a', {} as GenericResponse);
 const requestSenderFactory = new HttpRequestSenderBuilder(requester, expectedUrl, dummyAuthProviders);
+const customUrlRequestSenderFactory = new HttpRequestSenderBuilder(requester, expectedCustomUrl, dummyAuthProviders);
 
 
 describe('HttpClientBuilder', () => {
@@ -46,6 +51,20 @@ describe('HttpClientBuilder', () => {
     const expectedClient = DefaultDittoHttpClient.getInstance(requestSenderFactory);
     const dittoHttpClientV2 = HttpClientBuilder.newBuilder(requester)
       .withTls()
+      .withDomain('eclipse.ditto.org')
+      .withAuthProvider(dummyAuthProvider1, dummyAuthProvider2)
+      .apiVersion2()
+      .build();
+
+    expect(dittoHttpClientV2).toBeTruthy();
+    expect(dittoHttpClientV2).toEqual(expectedClient);
+  });
+
+  it('builds a new http client with custom path', () => {
+    const expectedClient = DefaultDittoHttpClient.getInstance(customUrlRequestSenderFactory);
+    const dittoHttpClientV2 = HttpClientBuilder.newBuilder(requester)
+      .withTls()
+      .withCustomPath('/secure-api')
       .withDomain('eclipse.ditto.org')
       .withAuthProvider(dummyAuthProvider1, dummyAuthProvider2)
       .apiVersion2()

--- a/javascript/lib/api/tests/client/http/http.helper.ts
+++ b/javascript/lib/api/tests/client/http/http.helper.ts
@@ -22,27 +22,35 @@ export class HttpHelper extends Helper {
   private static readonly matcher = `http://${HttpHelper.domain}/api/`;
   private static readonly errorDomain = 'error.web';
   private static readonly errorUrl = `http://${HttpHelper.errorDomain}`;
-  private static readonly errorResponse: GenericResponse = { status: 403, headers: new Map<string, string>(), body: HttpHelper.errorBody };
+  private static readonly errorResponse: GenericResponse = {
+    status: 403,
+    headers: new Map<string, string>(),
+    body: HttpHelper.errorBody
+  };
   // TODO: having this statically is causing problems between tests. it should really be not static
   private static readonly requester: TestRequester = new TestRequester(HttpHelper.errorUrl, HttpHelper.errorResponse);
+
   public static readonly thingsClientV2: DittoHttpClientV2 = HttpHelper.buildHttpClient(HttpHelper.requester)
     .withoutTls()
     .withDomain(HttpHelper.domain)
     .withAuthProvider(HttpHelper.basicAuthProvider(HttpHelper.testName, HttpHelper.password))
     .apiVersion2()
     .build();
+
   public static readonly thingsClientV1: DittoHttpClientV1 = HttpHelper.buildHttpClient(HttpHelper.requester)
     .withoutTls()
     .withDomain(HttpHelper.domain)
     .withAuthProvider(HttpHelper.basicAuthProvider(HttpHelper.testName, HttpHelper.password))
     .apiVersion1()
     .build();
+
   public static readonly errorThingsClientV2: DittoHttpClientV2 = HttpHelper.buildHttpClient(HttpHelper.requester)
     .withoutTls()
     .withDomain(HttpHelper.errorDomain)
     .withAuthProvider(HttpHelper.basicAuthProvider(HttpHelper.testName, HttpHelper.password))
     .apiVersion2()
     .build();
+
   public static readonly errorThingsClientV1: DittoHttpClientV1 = HttpHelper.buildHttpClient(HttpHelper.requester)
     .withoutTls()
     .withDomain(HttpHelper.errorDomain)

--- a/javascript/lib/dom/README.md
+++ b/javascript/lib/dom/README.md
@@ -15,7 +15,7 @@ Basically it makes sense to trigger the build process once from
 the [parent module](../../README.md). Then you'll be able to
 use the default build process in here:
 
-```
+```shell
 npm install
 npm run build
 npm run lint
@@ -25,14 +25,14 @@ npm test
 
 ## Using
 
-```
+```shell
 # replace <ditto-major.minor> with the major and minor version number of Eclipse Ditto you are using.
 npm i --save  @eclipse/ditto-javascript-client-api_<ditto-major.minor> @eclipse/ditto-javascript-client-dom_<ditto-major.minor>
 ```
 
 Create an instance of a client:
 
-```
+```javascript
 const domain = 'localhost:8080';
 const username = 'ditto';
 const password = 'ditto';
@@ -45,6 +45,7 @@ const client = DittoDomClient.newHttpClient()
             .apiVersion2()
             .build();
 ```
+To use a path other than `/api` to connect to ditto, the optional step `.withCustomPath('/path/to/api')` can be used.
 
 To find out how to use the client, have a look at the [api documentation](../api/README.md#Using-the-client),
 since the API will stay the same no matter what implementation is used.

--- a/javascript/lib/node/README.md
+++ b/javascript/lib/node/README.md
@@ -10,7 +10,7 @@ Basically it makes sense to trigger the build process once from
 the [parent module](../../README.md). Then you'll be able to
 use the default build process in here:
 
-```
+```shell
 npm install
 npm run build
 npm run lint
@@ -20,14 +20,14 @@ npm test
 
 ## Using
 
-```
+```shell
 # replace <ditto-major.minor> with the major and minor version number of Eclipse Ditto you are using.
 npm i --save  @eclipse/ditto-javascript-client-api_<ditto-major.minor> @eclipse/ditto-javascript-client-node_<ditto-major.minor>
 ```
 
 Create an instance of a client:
 
-```
+```javascript
 const domain = 'localhost:8080';
 const username = 'ditto';
 const password = 'ditto';
@@ -40,6 +40,7 @@ const client = DittoNodeClient.newHttpClient()
             .apiVersion2()
             .build();
 ```
+To use a path other than `/api` to connect to ditto, the optional step `.withCustomPath('/path/to/api')` can be used.
 
 To find out how to use the client, have a look at the [api documentation](../api/README.md#Using-the-client),
 since the API will stay the same no matter what implementation is used.
@@ -50,7 +51,7 @@ The Node.js implementation supports setting up a proxy.
 Currently it supports either reading directly from 'https_proxy' (or 'HTTPS_PROXY') environment variable
 or manually setting the proxy settings.
 
-```
+```javascript
 // may also omit one or more of the options
 const proxyOptions = {
   url: 'PROXY-URL:PROXYPORT',


### PR DESCRIPTION
For our use case, we have multiple different endpoint paths for ditto for different authentication methods, i.e. `/api/2` for basic http auth and something along the lines of `/secure-api/2` for token-based auth.

For this purpose, I added an additional (optional) step to the `AbstractBuilder` that lets the user set a custom path to the API.

I hope this feature is not to niche to be merged and I'm looking forward to your feedback!