### PR TITLE
Remove IIFE build 

### DIFF
--- a/javascript/lib/api/package.json
+++ b/javascript/lib/api/package.json
@@ -7,7 +7,6 @@
   "license": "SEE LICENSE IN LICENSE",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
-  "browser": "dist/index.bundle.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"

--- a/javascript/lib/api/rollup.config.js
+++ b/javascript/lib/api/rollup.config.js
@@ -26,12 +26,6 @@ export default {
             file: pkg.module,
             format: 'es',
             sourcemap: true
-        },
-        {
-            file: pkg.browser,
-            format: 'iife',
-            name: 'EclipseDittoJavascriptClientApi',
-            sourcemap: true
         }
     ],
     external: [

--- a/javascript/lib/dom/package.json
+++ b/javascript/lib/dom/package.json
@@ -7,7 +7,6 @@
   "license": "SEE LICENSE IN LICENSE",
   "module": "./dist/index.js",
   "main": "./dist/index.js",
-  "browser": "./dist/index.bundle.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {
     "access": "public"

--- a/javascript/lib/dom/rollup.config.js
+++ b/javascript/lib/dom/rollup.config.js
@@ -21,15 +21,6 @@ export default {
             file: pkg.module,
             format: 'es',
             sourcemap: true
-        },
-        {
-            file: pkg.browser,
-            format: 'iife',
-            name: 'EclipseDittoJavascriptClient',
-            sourcemap: true,
-            globals: {
-                '@eclipse-ditto/ditto-javascript-client-api_1.0': 'EclipseDittoJavascriptClientApi'
-            }
         }
     ],
     external: [


### PR DESCRIPTION
To fix the compatibility issues with webpack & co, remove the IIFE and `browser` fields from the build config.
Instead, ES6 modules can be used for browser and webpack.

Fixes #28 