### PR TITLE
Refactor model structure

### DIFF
--- a/javascript/lib/api/src/client/handles/features.ts
+++ b/javascript/lib/api/src/client/handles/features.ts
@@ -140,7 +140,7 @@ export class DefaultFeaturesHandle implements FeaturesHandle {
       id: this.thingId,
       path: 'features',
       requestOptions: options,
-      payload: features.toObject()
+      payload: Features.toObject(features)
     });
   }
 

--- a/javascript/lib/api/src/client/handles/policies.ts
+++ b/javascript/lib/api/src/client/handles/policies.ts
@@ -377,7 +377,7 @@ export class DefaultPoliciesHandle implements PoliciesHandle {
       id: policyId,
       path: 'entries',
       requestOptions: options,
-      payload: entries.toObject()
+      payload: Entries.toObject(entries)
     });
   }
 
@@ -416,7 +416,7 @@ export class DefaultPoliciesHandle implements PoliciesHandle {
       id: policyId,
       path: `entries/${label}/subjects`,
       requestOptions: options,
-      payload: subjects.toObject()
+      payload: Subjects.toObject(subjects)
     });
   }
 
@@ -456,7 +456,7 @@ export class DefaultPoliciesHandle implements PoliciesHandle {
       id: policyId,
       path: `entries/${label}/resources`,
       requestOptions: options,
-      payload: resources.toObject()
+      payload: Resources.toObject(resources)
     });
   }
 

--- a/javascript/lib/api/src/client/handles/things.ts
+++ b/javascript/lib/api/src/client/handles/things.ts
@@ -201,7 +201,7 @@ export class DefaultThingsHandle implements WebSocketThingsHandle, HttpThingsHan
       id: thingId,
       path: 'acl',
       requestOptions: options,
-      payload: acl.toObject()
+      payload: Acl.toObject(acl)
     });
   }
 

--- a/javascript/lib/api/src/model/model.ts
+++ b/javascript/lib/api/src/model/model.ts
@@ -136,7 +136,7 @@ export abstract class IndexedEntityModel<EntryType extends EntityModel> implemen
    */
   static toObject<T extends EntityModel>(entityModel: IndexedEntityModel<T>): Object | undefined {
     if (entityModel != null) {
-      return IndexedEntityModel.toPlainObject(entityModel, element => (<T>element).toObject());
+      return IndexedEntityModel.toPlainObject(entityModel, element => element.toObject());
     }
     return undefined;
   }

--- a/javascript/lib/api/src/model/model.ts
+++ b/javascript/lib/api/src/model/model.ts
@@ -83,6 +83,14 @@ export abstract class IndexedEntityModel<EntryType extends EntityModel> implemen
 
   [key: string]: EntryType;
 
+  static toJson<T extends EntityModel>(entity: IndexedEntityModel<T>): string {
+    return JSON.stringify(this.toObject(entity));
+  }
+
+  static equals<T extends EntityModel>(a: IndexedEntityModel<T>, b: IndexedEntityModel<T>): boolean {
+    return a !== undefined && b !== undefined && (a === b || this.toJson(a) === this.toJson(b));
+  }
+
   /**
    * Map the object to an indexed object with types. Iterates all keys and maps all values with {@code mapValue}.
    *
@@ -128,7 +136,7 @@ export abstract class IndexedEntityModel<EntryType extends EntityModel> implemen
    */
   static toObject<T extends EntityModel>(entityModel: IndexedEntityModel<T>): Object | undefined {
     if (entityModel != null) {
-      return IndexedEntityModel.toPlainObject(entityModel, element => (<T> element).toObject());
+      return IndexedEntityModel.toPlainObject(entityModel, element => (<T>element).toObject());
     }
     return undefined;
   }

--- a/javascript/lib/api/src/model/model.ts
+++ b/javascript/lib/api/src/model/model.ts
@@ -14,7 +14,7 @@
 /**
  * Model to represent an Entity in Ditto.
  */
-export abstract class EntityModel<T extends EntityModel<T>> {
+export abstract class EntityModel {
 
   /**
    * Turns an object into an array of the type A. It contains one Entity for every key of the original object
@@ -24,7 +24,7 @@ export abstract class EntityModel<T extends EntityModel<T>> {
    * @param parser - A method to parse instances of the desired Entity.
    * @returns The array of Entities.
    */
-  static objectToArray<T extends EntityWithId<T>>(o: Object, parser: (obj: Object, key: string) => T): T[] {
+  static objectToArray<T extends EntityWithId>(o: Object, parser: (obj: Object, key: string) => T): T[] {
     return Object.keys(o).map((key: string) => {
       // @ts-ignore
       return parser(o[key], key);
@@ -51,7 +51,7 @@ export abstract class EntityModel<T extends EntityModel<T>> {
     return JSON.stringify(this.toObject());
   }
 
-  equals(toCompare: T): boolean {
+  equals(toCompare: EntityModel): boolean {
     // @ts-ignore
     return toCompare !== undefined && (this === toCompare || this.toJson() === toCompare.toJson());
   }
@@ -67,34 +67,21 @@ export abstract class EntityModel<T extends EntityModel<T>> {
 /**
  * Entity with an 'id' field
  */
-export abstract class EntityWithId<T extends EntityWithId<T>> extends EntityModel<T> {
+export abstract class EntityWithId extends EntityModel {
   id!: string;
 
-  equals(toCompare: T): boolean {
+  equals(toCompare: EntityWithId): boolean {
     return super.equals(toCompare) && this.id === toCompare.id;
   }
 }
 
-/**
- * Type that can be used for entities with unknown property keys but known property values.
- * E.g. an entity that has user-defined keys but the values are always of the same type.
- * In typescript such interfaces are called 'index signatures'.
- */
-export interface IndexedEntityModelType<T> {
-  [index: string]: T;
-}
 
 /**
  * Abstract entity model class that consists of entities of the same type but with unknown property keys.
- * @param <T> - Type of the implementing class.
- * @param <V> - Type of the entities that are stored by the model.
  */
-export abstract class IndexedEntityModel<T extends IndexedEntityModel<T, V>, V>
-  extends EntityModel<IndexedEntityModel<T, V>> {
+export abstract class IndexedEntityModel<EntryType extends EntityModel> implements Record<string, EntryType> {
 
-  protected constructor(private readonly _elements: IndexedEntityModelType<V> | undefined) {
-    super();
-  }
+  [key: string]: EntryType;
 
   /**
    * Map the object to an indexed object with types. Iterates all keys and maps all values with {@code mapValue}.
@@ -103,9 +90,9 @@ export abstract class IndexedEntityModel<T extends IndexedEntityModel<T, V>, V>
    * @param mapValue - how to get the value from an objects value.
    * @param mapKey - how to get the key from an objects key.
    */
-  static fromPlainObject<T>(objectToMap: Object | undefined,
-                            mapValue: (value: any, key: string) => T,
-                            mapKey: (key: string, value: any) => string = key => key): IndexedEntityModelType<T> | undefined {
+  static fromPlainObject<T extends EntityModel>(objectToMap: Object | undefined,
+    mapValue: (value: any, key: string) => T,
+    mapKey: (key: string, value: any) => string = key => key): IndexedEntityModel<T> | undefined {
     if (objectToMap) {
       const entries = Object.keys(objectToMap)
         .map(k => {
@@ -126,7 +113,7 @@ export abstract class IndexedEntityModel<T extends IndexedEntityModel<T, V>, V>
    * @param objectToMap - the object to map.
    * @param removeType - function that is called to remove the type of the objects values.
    */
-  static toPlainObject<T>(objectToMap: IndexedEntityModelType<T>, removeType: (typedObject: T) => any) {
+  static toPlainObject<T extends EntityModel>(objectToMap: IndexedEntityModel<T>, removeType: (typedObject: T) => any) {
     const entries = Object.keys(objectToMap)
       .map(k => {
         return { [k]: removeType(objectToMap[k]) };
@@ -139,10 +126,9 @@ export abstract class IndexedEntityModel<T extends IndexedEntityModel<T, V>, V>
    *
    * @returns The object representation of the Entity.
    */
-  toObject(): Object | undefined {
-    if (this._elements) {
-      // @ts-ignore
-      return IndexedEntityModel.toPlainObject(this._elements, element => element.toObject());
+  static toObject<T extends EntityModel>(entityModel: IndexedEntityModel<T>): Object | undefined {
+    if (entityModel != null) {
+      return IndexedEntityModel.toPlainObject(entityModel, element => (<T> element).toObject());
     }
     return undefined;
   }

--- a/javascript/lib/api/src/model/model.ts
+++ b/javascript/lib/api/src/model/model.ts
@@ -100,7 +100,7 @@ export abstract class IndexedEntityModel<EntryType extends EntityModel> implemen
    */
   static fromPlainObject<T extends EntityModel>(objectToMap: Object | undefined,
     mapValue: (value: any, key: string) => T,
-    mapKey: (key: string, value: any) => string = key => key): IndexedEntityModel<T> | undefined {
+    mapKey: (key: string, value: any) => string = key => key): IndexedEntityModel<T> {
     if (objectToMap) {
       const entries = Object.keys(objectToMap)
         .map(k => {
@@ -113,7 +113,7 @@ export abstract class IndexedEntityModel<EntryType extends EntityModel> implemen
       return Object.assign({}, ...entries);
     }
 
-    return undefined;
+    return {};
   }
 
   /**
@@ -134,7 +134,7 @@ export abstract class IndexedEntityModel<EntryType extends EntityModel> implemen
    *
    * @returns The object representation of the Entity.
    */
-  static toObject<T extends EntityModel>(entityModel: IndexedEntityModel<T>): Object | undefined {
+  static toObject<T extends EntityModel>(entityModel: IndexedEntityModel<T> | undefined): Object | undefined {
     if (entityModel != null) {
       return IndexedEntityModel.toPlainObject(entityModel, element => element.toObject());
     }

--- a/javascript/lib/api/src/model/policies.model.ts
+++ b/javascript/lib/api/src/model/policies.model.ts
@@ -67,11 +67,11 @@ export class Entries extends IndexedEntityModel<Entry> {
    * @param o - The object to parse.
    * @returns The Entries
    */
-  public static fromObject(o: any): Entries | undefined {
+  public static fromObject(o: any): Entries {
     if (o === undefined) {
       return o;
     }
-    return this.fromPlainObject(o, Entry.fromObject);
+    return IndexedEntityModel.fromPlainObject(o, Entry.fromObject) || {};
   }
 
 }
@@ -136,11 +136,11 @@ export class Subjects extends IndexedEntityModel<Subject> {
    * @param o - The object to parse.
    * @returns The Subjects
    */
-  public static fromObject(o: any): Subjects | undefined {
+  public static fromObject(o: any): Subjects {
     if (o === undefined) {
       return o;
     }
-    return IndexedEntityModel.fromPlainObject(o, Subject.fromObject, key => key);
+    return IndexedEntityModel.fromPlainObject(o, Subject.fromObject, key => key) || {};
   }
 }
 
@@ -155,11 +155,11 @@ export class Resources extends IndexedEntityModel<Resource> {
    * @param o - The object to parse.
    * @returns The Resources
    */
-  public static fromObject(o: any): Resources | undefined {
+  public static fromObject(o: any): Resources  {
     if (o === undefined) {
       return o;
     }
-    return IndexedEntityModel.fromPlainObject(o, Resource.fromObject);
+    return IndexedEntityModel.fromPlainObject(o, Resource.fromObject) || {};
   }
 }
 

--- a/javascript/lib/api/src/model/policies.model.ts
+++ b/javascript/lib/api/src/model/policies.model.ts
@@ -39,7 +39,7 @@ export class Policy extends EntityWithId {
   }
 
   public toObject(): Object {
-    const entriesObj = this.entries !== undefined ? Entries.toObject(this.entries) : undefined;
+    const entriesObj = Entries.toObject(this.entries);
     return EntityModel.buildObject(new Map<string, any>([
       ['entries', entriesObj]
     ]));
@@ -71,8 +71,7 @@ export class Entries extends IndexedEntityModel<Entry> {
     if (o === undefined) {
       return o;
     }
-    const entries = IndexedEntityModel.fromPlainObject(o, Entry.fromObject);
-    return entries != null ? entries : {};
+    return IndexedEntityModel.fromPlainObject(o, Entry.fromObject);
   }
 
 }
@@ -104,8 +103,8 @@ export class Entry extends EntityWithId {
   }
 
   public toObject(): Object {
-    const subjectsObj = this.subjects !== undefined ? Subjects.toObject(this.subjects) : undefined;
-    const resourcesObj = this.resources !== undefined ? Resources.toObject(this.resources) : undefined;
+    const subjectsObj = Subjects.toObject(this.subjects) ;
+    const resourcesObj = Resources.toObject(this.resources);
     return EntityModel.buildObject(new Map<string, any>([
       ['subjects', subjectsObj],
       ['resources', resourcesObj]
@@ -141,8 +140,7 @@ export class Subjects extends IndexedEntityModel<Subject> {
     if (o === undefined) {
       return o;
     }
-    const subjects = IndexedEntityModel.fromPlainObject(o, Subject.fromObject, key => key);
-    return subjects != null ? subjects : {};
+    return IndexedEntityModel.fromPlainObject(o, Subject.fromObject, key => key);
   }
 }
 
@@ -161,8 +159,7 @@ export class Resources extends IndexedEntityModel<Resource> {
     if (o === undefined) {
       return o;
     }
-    const resources = IndexedEntityModel.fromPlainObject(o, Resource.fromObject);
-    return resources != null ? resources : {};
+    return IndexedEntityModel.fromPlainObject(o, Resource.fromObject);
   }
 }
 

--- a/javascript/lib/api/src/model/policies.model.ts
+++ b/javascript/lib/api/src/model/policies.model.ts
@@ -71,7 +71,8 @@ export class Entries extends IndexedEntityModel<Entry> {
     if (o === undefined) {
       return o;
     }
-    return IndexedEntityModel.fromPlainObject(o, Entry.fromObject) || {};
+    const entries = IndexedEntityModel.fromPlainObject(o, Entry.fromObject);
+    return entries != null ? entries : {};
   }
 
 }
@@ -140,7 +141,8 @@ export class Subjects extends IndexedEntityModel<Subject> {
     if (o === undefined) {
       return o;
     }
-    return IndexedEntityModel.fromPlainObject(o, Subject.fromObject, key => key) || {};
+    const subjects = IndexedEntityModel.fromPlainObject(o, Subject.fromObject, key => key);
+    return subjects != null ? subjects : {};
   }
 }
 
@@ -155,11 +157,12 @@ export class Resources extends IndexedEntityModel<Resource> {
    * @param o - The object to parse.
    * @returns The Resources
    */
-  public static fromObject(o: any): Resources  {
+  public static fromObject(o: any): Resources {
     if (o === undefined) {
       return o;
     }
-    return IndexedEntityModel.fromPlainObject(o, Resource.fromObject) || {};
+    const resources = IndexedEntityModel.fromPlainObject(o, Resource.fromObject);
+    return resources != null ? resources : {};
   }
 }
 

--- a/javascript/lib/api/src/model/policies.model.ts
+++ b/javascript/lib/api/src/model/policies.model.ts
@@ -16,10 +16,10 @@ import { EntityModel, EntityWithId, IndexedEntityModel } from './model';
 /**
  * Representation of a Policy
  */
-export class Policy extends EntityWithId<Policy> {
+export class Policy extends EntityWithId {
 
   public constructor(private readonly _id: string,
-                     private readonly _entries: Entries) {
+    private readonly _entries: Entries) {
     super();
   }
 
@@ -39,7 +39,7 @@ export class Policy extends EntityWithId<Policy> {
   }
 
   public toObject(): Object {
-    const entriesObj = this.entries !== undefined ? this.entries.toObject() : undefined;
+    const entriesObj = this.entries !== undefined ? Entries.toObject(this.entries) : undefined;
     return EntityModel.buildObject(new Map<string, any>([
       ['entries', entriesObj]
     ]));
@@ -54,18 +54,12 @@ export class Policy extends EntityWithId<Policy> {
   }
 }
 
-interface EntriesType {
-  [entryId: string]: Entry;
-}
 
 /**
  * Representation of Entries
  */
-export class Entries extends IndexedEntityModel<Entries, Entry> {
+export class Entries extends IndexedEntityModel<Entry> {
 
-  public constructor(readonly entries: EntriesType | undefined) {
-    super(entries);
-  }
 
   /**
    * Parses Entries.
@@ -73,11 +67,11 @@ export class Entries extends IndexedEntityModel<Entries, Entry> {
    * @param o - The object to parse.
    * @returns The Entries
    */
-  public static fromObject(o: any): Entries {
+  public static fromObject(o: any): Entries | undefined {
     if (o === undefined) {
       return o;
     }
-    return new Entries(IndexedEntityModel.fromPlainObject(o, Entry.fromObject));
+    return this.fromPlainObject(o, Entry.fromObject);
   }
 
 }
@@ -85,11 +79,11 @@ export class Entries extends IndexedEntityModel<Entries, Entry> {
 /**
  * Representation of an Entry
  */
-export class Entry extends EntityWithId<Entry> {
+export class Entry extends EntityWithId {
 
   public constructor(private readonly _id: string,
-                     private readonly _subjects: Subjects,
-                     private readonly _resources: Resources) {
+    private readonly _subjects: Subjects,
+    private readonly _resources: Resources) {
     super();
   }
 
@@ -109,8 +103,8 @@ export class Entry extends EntityWithId<Entry> {
   }
 
   public toObject(): Object {
-    const subjectsObj = this.subjects !== undefined ? this.subjects.toObject() : undefined;
-    const resourcesObj = this.resources !== undefined ? this.resources.toObject() : undefined;
+    const subjectsObj = this.subjects !== undefined ? Subjects.toObject(this.subjects) : undefined;
+    const resourcesObj = this.resources !== undefined ? Resources.toObject(this.resources) : undefined;
     return EntityModel.buildObject(new Map<string, any>([
       ['subjects', subjectsObj],
       ['resources', resourcesObj]
@@ -130,18 +124,11 @@ export class Entry extends EntityWithId<Entry> {
   }
 }
 
-interface SubjectsType {
-  [subjectId: string]: Subject;
-}
 
 /**
  * Representation of Subjects
  */
-export class Subjects extends IndexedEntityModel<Subjects, Subject> {
-
-  public constructor(readonly subjects: SubjectsType | undefined) {
-    super(subjects);
-  }
+export class Subjects extends IndexedEntityModel<Subject> {
 
   /**
    * Parses Subjects.
@@ -149,26 +136,18 @@ export class Subjects extends IndexedEntityModel<Subjects, Subject> {
    * @param o - The object to parse.
    * @returns The Subjects
    */
-  public static fromObject(o: any): Subjects {
+  public static fromObject(o: any): Subjects | undefined {
     if (o === undefined) {
       return o;
     }
-    return new Subjects(IndexedEntityModel.fromPlainObject(o, Subject.fromObject, key => key));
+    return IndexedEntityModel.fromPlainObject(o, Subject.fromObject, key => key);
   }
-}
-
-interface ResourcesType {
-  [resourceId: string]: Resource;
 }
 
 /**
  * Representation of Resources
  */
-export class Resources extends IndexedEntityModel<Resources, Resource> {
-
-  public constructor(readonly resources: ResourcesType | undefined) {
-    super(resources);
-  }
+export class Resources extends IndexedEntityModel<Resource> {
 
   /**
    * Parses Resources.
@@ -176,11 +155,11 @@ export class Resources extends IndexedEntityModel<Resources, Resource> {
    * @param o - The object to parse.
    * @returns The Resources
    */
-  public static fromObject(o: any): Resources {
+  public static fromObject(o: any): Resources | undefined {
     if (o === undefined) {
       return o;
     }
-    return new Resources(IndexedEntityModel.fromPlainObject(o, Resource.fromObject));
+    return IndexedEntityModel.fromPlainObject(o, Resource.fromObject);
   }
 }
 
@@ -199,6 +178,7 @@ export class SubjectId {
   static fromIssuerAndId(issuer: SubjectIssuer, subjectId: string) {
     return new SubjectId(`${issuer}:${subjectId}`);
   }
+
   static fromString(subjectId: string) {
     return new SubjectId(subjectId);
   }
@@ -213,10 +193,10 @@ export type SubjectType = string;
 /**
  * Representation of a Subject
  */
-export class Subject extends EntityWithId<Subject> {
+export class Subject extends EntityWithId {
 
   public constructor(private readonly _id: SubjectId,
-                     private readonly _type: SubjectType) {
+    private readonly _type: SubjectType) {
     super();
   }
 
@@ -258,11 +238,11 @@ export enum AccessRight {
 /**
  * Representation of a Resource
  */
-export class Resource extends EntityWithId<Resource> {
+export class Resource extends EntityWithId {
 
   public constructor(private readonly _id: string,
-                     private readonly _grant: AccessRight[],
-                     private readonly _revoke: AccessRight[]) {
+    private readonly _grant: AccessRight[],
+    private readonly _revoke: AccessRight[]) {
     super();
   }
 

--- a/javascript/lib/api/src/model/response.ts
+++ b/javascript/lib/api/src/model/response.ts
@@ -57,7 +57,7 @@ export class PutResponse<T> implements GenericResponse {
 /**
  * Representation of a response ot a search request
  */
-export class SearchThingsResponse extends EntityModel<SearchThingsResponse> {
+export class SearchThingsResponse extends EntityModel {
 
   public constructor(private readonly _items: Thing[],
                      private readonly _nextPageOffset?: number,

--- a/javascript/lib/api/src/model/things.model.ts
+++ b/javascript/lib/api/src/model/things.model.ts
@@ -131,7 +131,8 @@ export class Features extends IndexedEntityModel<Feature> {
     if (o === undefined) {
       return o;
     }
-    return IndexedEntityModel.fromPlainObject<Feature>(o, Feature.fromObject) || {};
+    const features = IndexedEntityModel.fromPlainObject<Feature>(o, Feature.fromObject);
+    return features != null ? features : {};
   }
 }
 
@@ -193,7 +194,8 @@ export class Acl extends IndexedEntityModel<AclEntry> {
     if (o === undefined) {
       return o;
     }
-    return IndexedEntityModel.fromPlainObject<AclEntry>(o, AclEntry.fromObject) || {};
+    const acl = IndexedEntityModel.fromPlainObject<AclEntry>(o, AclEntry.fromObject);
+    return acl != null ? acl : {};
   }
 }
 

--- a/javascript/lib/api/src/model/things.model.ts
+++ b/javascript/lib/api/src/model/things.model.ts
@@ -51,8 +51,8 @@ export class Thing extends EntityWithId {
   }
 
   public toObject(): object {
-    const featuresObj = this.features ? Features.toObject(this.features) : undefined;
-    const aclObj = this._acl ? Acl.toObject(this._acl) : undefined;
+    const featuresObj = Features.toObject(this.features);
+    const aclObj = Acl.toObject(this._acl);
     return EntityModel.buildObject(new Map<string, any>([
       ['thingId', this.thingId],
       ['policyId', this.policyId],
@@ -198,8 +198,7 @@ export class Acl extends IndexedEntityModel<AclEntry> {
     if (o === undefined) {
       return o;
     }
-    const acl = IndexedEntityModel.fromPlainObject<AclEntry>(o, AclEntry.fromObject);
-    return acl != null ? acl : {};
+    return IndexedEntityModel.fromPlainObject<AclEntry>(o, AclEntry.fromObject);
   }
 }
 

--- a/javascript/lib/api/src/model/things.model.ts
+++ b/javascript/lib/api/src/model/things.model.ts
@@ -133,8 +133,7 @@ export class Features extends IndexedEntityModel<Feature> {
     if (o === undefined) {
       return o;
     }
-    const features = IndexedEntityModel.fromPlainObject<Feature>(o, Feature.fromObject);
-    return features != null ? features : {};
+    return IndexedEntityModel.fromPlainObject<Feature>(o, Feature.fromObject);
   }
 }
 

--- a/javascript/lib/api/src/model/things.model.ts
+++ b/javascript/lib/api/src/model/things.model.ts
@@ -121,6 +121,8 @@ export class Thing extends EntityWithId {
  */
 export class Features extends IndexedEntityModel<Feature> {
 
+  [featureId: string]: Feature
+
   /**
    * Parses Features.
    *
@@ -143,7 +145,7 @@ export class Feature extends EntityWithId {
 
   public constructor(private readonly _id: string,
     private readonly _definition?: string[],
-    private readonly _properties?: object) {
+    private readonly _properties?: Record<string, any>) {
     super();
   }
 
@@ -177,12 +179,14 @@ export class Feature extends EntityWithId {
     return this._definition;
   }
 
-  get properties(): object | undefined {
+  get properties(): Record<string, any> | undefined {
     return this._properties;
   }
 }
 
 export class Acl extends IndexedEntityModel<AclEntry> {
+
+  [entryId: string]: AclEntry
 
   /**
    * Parses Acl.

--- a/javascript/lib/api/src/model/things.model.ts
+++ b/javascript/lib/api/src/model/things.model.ts
@@ -16,17 +16,17 @@ import { EntityModel, EntityWithId, IndexedEntityModel } from './model';
 /**
  * Representation of a Thing
  */
-export class Thing extends EntityWithId<Thing> {
+export class Thing extends EntityWithId {
 
   public static readonly NAMESPACE_SEPARATION_REGEX = /([^:]*):(.*)/;
 
   public constructor(private readonly _thingId: string,
-                     private readonly _policyId?: string,
-                     private readonly _attributes?: object,
-                     private readonly _features?: Features,
-                     private readonly __revision?: number,
-                     private readonly __modified?: string,
-                     private readonly _acl?: Acl) {
+    private readonly _policyId?: string,
+    private readonly _attributes?: object,
+    private readonly _features?: Features,
+    private readonly __revision?: number,
+    private readonly __modified?: string,
+    private readonly _acl?: Acl) {
     super();
   }
 
@@ -51,8 +51,8 @@ export class Thing extends EntityWithId<Thing> {
   }
 
   public toObject(): object {
-    const featuresObj = this.features ? this.features.toObject() : undefined;
-    const aclObj = this._acl ? this._acl.toObject() : undefined;
+    const featuresObj = this.features ? Features.toObject(this.features) : undefined;
+    const aclObj = this._acl ? Acl.toObject(this._acl) : undefined;
     return EntityModel.buildObject(new Map<string, any>([
       ['thingId', this.thingId],
       ['policyId', this.policyId],
@@ -115,18 +115,11 @@ export class Thing extends EntityWithId<Thing> {
   }
 }
 
-interface FeaturesType {
-  [featureId: string]: Feature;
-}
 
 /**
  * Representation of Features
  */
-export class Features extends IndexedEntityModel<Features, Feature> {
-
-  public constructor(readonly features?: FeaturesType) {
-    super(features);
-  }
+export class Features extends IndexedEntityModel<Feature> {
 
   /**
    * Parses Features.
@@ -134,22 +127,22 @@ export class Features extends IndexedEntityModel<Features, Feature> {
    * @param o - The object to parse.
    * @returns The Features
    */
-  public static fromObject(o: any): Features {
+  public static fromObject(o: any): Features | undefined {
     if (o === undefined) {
       return o;
     }
-    return new Features(IndexedEntityModel.fromPlainObject(o, Feature.fromObject));
+    return IndexedEntityModel.fromPlainObject<Feature>(o, Feature.fromObject);
   }
 }
 
 /**
  * Representation of a Feature
  */
-export class Feature extends EntityWithId<Feature> {
+export class Feature extends EntityWithId {
 
   public constructor(private readonly _id: string,
-                     private readonly _definition?: string[],
-                     private readonly _properties?: object) {
+    private readonly _definition?: string[],
+    private readonly _properties?: object) {
     super();
   }
 
@@ -188,15 +181,7 @@ export class Feature extends EntityWithId<Feature> {
   }
 }
 
-interface AclType {
-  [aclEntryId: string]: AclEntry;
-}
-
-export class Acl extends IndexedEntityModel<Acl, AclEntry> {
-
-  public constructor(readonly aclEntries?: AclType) {
-    super(aclEntries);
-  }
+export class Acl extends IndexedEntityModel<AclEntry> {
 
   /**
    * Parses Acl.
@@ -204,20 +189,20 @@ export class Acl extends IndexedEntityModel<Acl, AclEntry> {
    * @param o - The object to parse.
    * @returns The Acl
    */
-  public static fromObject(o: any): Acl {
+  public static fromObject(o: any): Acl | undefined {
     if (o === undefined) {
       return o;
     }
-    return new Acl(IndexedEntityModel.fromPlainObject(o, AclEntry.fromObject));
+    return IndexedEntityModel.fromPlainObject<AclEntry>(o, AclEntry.fromObject);
   }
 }
 
-export class AclEntry extends EntityWithId<AclEntry> {
+export class AclEntry extends EntityWithId {
 
   public constructor(private readonly _id: string,
-                     private readonly _read: boolean,
-                     private readonly _write: boolean,
-                     private readonly _administrate: boolean) {
+    private readonly _read: boolean,
+    private readonly _write: boolean,
+    private readonly _administrate: boolean) {
     super();
   }
 

--- a/javascript/lib/api/src/model/things.model.ts
+++ b/javascript/lib/api/src/model/things.model.ts
@@ -22,7 +22,7 @@ export class Thing extends EntityWithId {
 
   public constructor(private readonly _thingId: string,
     private readonly _policyId?: string,
-    private readonly _attributes?: object,
+    private readonly _attributes?: Record<string, any>,
     private readonly _features?: Features,
     private readonly __revision?: number,
     private readonly __modified?: string,

--- a/javascript/lib/api/src/model/things.model.ts
+++ b/javascript/lib/api/src/model/things.model.ts
@@ -127,11 +127,11 @@ export class Features extends IndexedEntityModel<Feature> {
    * @param o - The object to parse.
    * @returns The Features
    */
-  public static fromObject(o: any): Features | undefined {
+  public static fromObject(o: any): Features {
     if (o === undefined) {
       return o;
     }
-    return IndexedEntityModel.fromPlainObject<Feature>(o, Feature.fromObject);
+    return IndexedEntityModel.fromPlainObject<Feature>(o, Feature.fromObject) || {};
   }
 }
 
@@ -189,11 +189,11 @@ export class Acl extends IndexedEntityModel<AclEntry> {
    * @param o - The object to parse.
    * @returns The Acl
    */
-  public static fromObject(o: any): Acl | undefined {
+  public static fromObject(o: any): Acl {
     if (o === undefined) {
       return o;
     }
-    return IndexedEntityModel.fromPlainObject<AclEntry>(o, AclEntry.fromObject);
+    return IndexedEntityModel.fromPlainObject<AclEntry>(o, AclEntry.fromObject) || {};
   }
 }
 

--- a/javascript/lib/api/tests/client/http/features.http.spec.ts
+++ b/javascript/lib/api/tests/client/http/features.http.spec.ts
@@ -15,6 +15,7 @@
 import { FeaturesHandle } from '../../../src/client/handles/features.interfaces';
 import { PutResponse } from '../../../src/model/response';
 import { HttpHelper as H } from './http.helper';
+import { Features } from '../../../src/model/things.model';
 
 describe('Http Features Handle', () => {
   const baseRequest = `things/${H.thing.thingId}/features`;
@@ -24,7 +25,7 @@ describe('Http Features Handle', () => {
   it('gets Features', () => {
     return H.test({
       toTest: () => handle.getFeatures(),
-      testBody: H.features.toObject(),
+      testBody: Features.toObject(H.features),
       expected: H.features,
       request: baseRequest,
       method: 'get',
@@ -79,12 +80,12 @@ describe('Http Features Handle', () => {
   it('updates Features', () => {
     return H.test({
       toTest: () => handle.putFeatures(H.features),
-      testBody: H.features.toObject(),
+      testBody: Features.toObject(H.features),
       expected: new PutResponse(H.features, 201, undefined),
       request: baseRequest,
       method: 'put',
       status: 201,
-      payload: H.features.toJson()
+      payload: Features.toJson(H.features)
     });
   });
 

--- a/javascript/lib/api/tests/client/http/policies.http.spec.ts
+++ b/javascript/lib/api/tests/client/http/policies.http.spec.ts
@@ -13,15 +13,15 @@
 
 /* tslint:disable:no-big-function */
 import {
-  AccessRight, DittoSubjectIssuer,
+  AccessRight,
   Entries,
   Entry,
   Policy,
   Resource,
   Resources,
-  Subject, SubjectId,
-  Subjects,
-  SubjectType
+  Subject,
+  SubjectId,
+  Subjects
 } from '../../../src/model/policies.model';
 import { PutResponse } from '../../../src/model/response';
 import { HttpHelper as H } from './http.helper';
@@ -32,15 +32,15 @@ describe('Http Policies Handle', () => {
   const resourcePath = 'aResource';
   const aResource = new Resource(resourcePath, [AccessRight.Read], [AccessRight.Write]);
   const anotherResource = new Resource('anotherResource', [AccessRight.Write], [AccessRight.Write]);
-  const resources = new Resources({ aResource, anotherResource });
+  const resources = { aResource, anotherResource };
   const subjectId = 'nginx:aSubject';
   const aSubject = new Subject(SubjectId.fromString(subjectId), 'my default nginx user');
   const anotherSubject = new Subject(SubjectId.fromString('anotherSubject'), 'my other nginx user');
-  const subjects = new Subjects({ [aSubject.id]: aSubject, [anotherSubject.id]: anotherSubject });
+  const subjects = { [aSubject.id]: aSubject, [anotherSubject.id]: anotherSubject };
   const label = 'anEntry';
   const anEntry = new Entry(label, subjects, resources);
   const anotherEntry = new Entry('anotherEntry', subjects, resources);
-  const entries = new Entries({ anEntry, anotherEntry });
+  const entries = { anEntry, anotherEntry };
   const policyId = 'Testspace:Testpolicy';
   const policy = new Policy(policyId, entries);
   const baseRequest = `policies/${policy.id}`;
@@ -60,7 +60,7 @@ describe('Http Policies Handle', () => {
   it('gets Entries', () => {
     return H.test({
       toTest: () => handle.getEntries(policy.id),
-      testBody: entries.toObject(),
+      testBody: Entries.toObject(entries),
       expected: entries,
       request: `${baseRequest}/entries`,
       method: 'get',
@@ -82,7 +82,7 @@ describe('Http Policies Handle', () => {
   it('gets Subjects', () => {
     return H.test({
       toTest: () => handle.getSubjects(policy.id, label),
-      testBody: subjects.toObject(),
+      testBody: Subjects.toObject(subjects),
       expected: subjects,
       request: `${baseRequest}/entries/${label}/subjects`,
       method: 'get',
@@ -104,7 +104,7 @@ describe('Http Policies Handle', () => {
   it('gets Resources', () => {
     return H.test({
       toTest: () => handle.getResources(policy.id, label),
-      testBody: resources.toObject(),
+      testBody: Resources.toObject(resources),
       expected: resources,
       request: `${baseRequest}/entries/${label}/resources`,
       method: 'get',
@@ -138,12 +138,12 @@ describe('Http Policies Handle', () => {
   it('updates Entries', () => {
     return H.test({
       toTest: () => handle.putEntries(policy.id, entries),
-      testBody: entries.toObject(),
+      testBody: Entries.toObject(entries),
       expected: new PutResponse(entries, 201, undefined),
       request: `${baseRequest}/entries`,
       method: 'put',
       status: 201,
-      payload: entries.toJson()
+      payload: Entries.toJson(entries)
     });
   });
 
@@ -162,12 +162,12 @@ describe('Http Policies Handle', () => {
   it('updates Subjects', () => {
     return H.test({
       toTest: () => handle.putSubjects(policy.id, label, subjects),
-      testBody: subjects.toObject(),
+      testBody: Subjects.toObject(subjects),
       expected: new PutResponse(subjects, 201, undefined),
       request: `${baseRequest}/entries/${label}/subjects`,
       method: 'put',
       status: 201,
-      payload: subjects.toJson()
+      payload: Subjects.toJson(subjects)
     });
   });
 
@@ -186,12 +186,12 @@ describe('Http Policies Handle', () => {
   it('updates Resources', () => {
     return H.test({
       toTest: () => handle.putResources(policy.id, label, resources),
-      testBody: resources.toObject(),
+      testBody: Resources.toObject(resources),
       expected: new PutResponse(resources, 201, undefined),
       request: `${baseRequest}/entries/${label}/resources`,
       method: 'put',
       status: 201,
-      payload: resources.toJson()
+      payload: Resources.toJson(resources)
     });
   });
 

--- a/javascript/lib/api/tests/client/http/things.http.spec.ts
+++ b/javascript/lib/api/tests/client/http/things.http.spec.ts
@@ -15,7 +15,11 @@
 import { HttpThingsHandleV1, HttpThingsHandleV2 } from '../../../src/client/handles/things.interfaces';
 import { PutResponse } from '../../../src/model/response';
 import { Acl, AclEntry } from '../../../src/model/things.model';
-import { DefaultFieldsOptions, DefaultGetThingsOptions, DefaultMatchOptions } from '../../../src/options/request.options';
+import {
+  DefaultFieldsOptions,
+  DefaultGetThingsOptions,
+  DefaultMatchOptions
+} from '../../../src/options/request.options';
 import { HttpHelper as H } from './http.helper';
 
 describe('Http Things Handle', () => {
@@ -27,7 +31,7 @@ describe('Http Things Handle', () => {
   const authorizationSubject = 'Id';
   const anAclEntry = new AclEntry(authorizationSubject, true, true, true);
   const anotherAclEntry = new AclEntry('Test', false, false, false);
-  const acl = new Acl({ [anAclEntry.id]: anAclEntry, [anotherAclEntry.id]: anotherAclEntry });
+  const acl = { [anAclEntry.id]: anAclEntry, [anotherAclEntry.id]: anotherAclEntry };
 
   it('sends options and gets a Thing', () => {
     const options = DefaultFieldsOptions.getInstance().withFields('A', 'B').ifMatch('C').ifNoneMatch('D');
@@ -105,7 +109,7 @@ describe('Http Things Handle', () => {
   it('gets an Acl', () => {
     return H.test({
       toTest: () => handleV1.getAcl(H.thing.thingId),
-      testBody: acl.toObject(),
+      testBody: Acl.toObject(acl),
       expected: acl,
       request: `${baseRequest}/acl`,
       method: 'get',
@@ -195,7 +199,7 @@ describe('Http Things Handle', () => {
       request: `${baseRequest}/acl`,
       method: 'put',
       status: 204,
-      payload: acl.toJson(),
+      payload: Acl.toJson(acl),
       api: 1
     });
   });

--- a/javascript/lib/api/tests/client/test.helper.ts
+++ b/javascript/lib/api/tests/client/test.helper.ts
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Feature, Features, Thing } from '../../src/model/things.model';
+import { Feature, Thing } from '../../src/model/things.model';
 import { AuthProvider, DittoHeaders, DittoURL } from '../../src/auth/auth-provider';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 0;
@@ -49,10 +49,10 @@ export class Helper {
   public static readonly properties = { A21: 'A3', A31: Helper.property };
   public static readonly feature = new Feature('F1', Helper.definition, Helper.properties);
   public static readonly anotherFeature = new Feature('F2', ['def2'], { A22: 'A3', A32: 'A4' });
-  public static readonly features = new Features({
+  public static readonly features = {
     [Helper.feature.id]: Helper.feature,
     [Helper.anotherFeature.id]: Helper.anotherFeature
-  });
+  };
 
 
   public static testError(method: () => Promise<any>): Promise<any> {

--- a/javascript/lib/api/tests/client/websocket/commands.websocket.spec.ts
+++ b/javascript/lib/api/tests/client/websocket/commands.websocket.spec.ts
@@ -13,6 +13,7 @@
 
 import { ProtocolResponseValue } from '../../../src/client/request-factory/websocket-request-handler';
 import { EventsHelper as H } from './events.helper';
+import { Features } from '../../../src/model/things.model';
 
 
 describe('WebSocket Commands Handle', () => {
@@ -90,7 +91,7 @@ describe('WebSocket Commands Handle', () => {
         topic,
         action,
         path: '/features',
-        value: H.features.toObject()
+        value: Features.toObject(H.features)
       }
     });
   });

--- a/javascript/lib/api/tests/client/websocket/events.websocket.spec.ts
+++ b/javascript/lib/api/tests/client/websocket/events.websocket.spec.ts
@@ -13,6 +13,7 @@
 
 import { ProtocolResponseValue } from '../../../src/client/request-factory/websocket-request-handler';
 import { EventsHelper as H } from './events.helper';
+import { Features } from '../../../src/model/things.model';
 
 
 describe('WebSocket Events Handle', () => {
@@ -90,7 +91,7 @@ describe('WebSocket Events Handle', () => {
         topic,
         action,
         path: '/features',
-        value: H.features.toObject()
+        value: Features.toObject(H.features)
       }
     });
   });

--- a/javascript/lib/api/tests/client/websocket/features.websocket.spec.ts
+++ b/javascript/lib/api/tests/client/websocket/features.websocket.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import { WebSocketHelper as H } from './websocket.helper';
+import { Features } from '../../../src/model/things.model';
 
 // tslint:disable-next-line:no-big-function
 describe('WebSocket Features Handle', () => {
@@ -25,7 +26,7 @@ describe('WebSocket Features Handle', () => {
       topic: `${baseTopic}/retrieve`,
       path: '/features',
       status: 200,
-      responseBody: H.features.toObject(),
+      responseBody: Features.toObject(H.features),
       expected: H.features
     });
   });
@@ -80,7 +81,7 @@ describe('WebSocket Features Handle', () => {
       topic: `${baseTopic}/modify`,
       path: '/features',
       status: 204,
-      requestBody: H.features.toObject()
+      requestBody: Features.toObject(H.features)
     });
   });
 

--- a/javascript/lib/api/tests/model/policies.model.spec.ts
+++ b/javascript/lib/api/tests/model/policies.model.spec.ts
@@ -32,18 +32,18 @@ const someMoreResourcesObj = { 'thing:/': aResourceObj };
 const aResource = new Resource('thing:/', [AccessRight.Read], [AccessRight.Read]);
 const anotherResource = new Resource('thing:/attributes/some/path', [AccessRight.Read], [AccessRight.Read]);
 const typedResources = { 'thing:/': aResource, 'thing:/attributes/some/path': anotherResource };
-const someResources = new Resources(typedResources);
-const someMoreResources = new Resources({ 'thing:/': aResource });
+const someResources = typedResources;
+const someMoreResources = { 'thing:/': aResource };
 const aSubject = new Subject(SubjectId.fromString('nginx:user'), 'my default nginx user');
 const anotherSubject = new Subject(SubjectId.fromIssuerAndId(DittoSubjectIssuer.GOOGLE, 'my-google-user@gmail.com'), 'my google user');
 const aLastSubject = new Subject(SubjectId.fromIssuerAndId(DittoSubjectIssuer.NGINX, 'admin'), 'my nginx admin user');
 const typedSubjects = { [aSubject.id]: aSubject, [anotherSubject.id]: anotherSubject };
-const someSubjects = new Subjects(typedSubjects);
-const someMoreSubjects = new Subjects({ [aLastSubject.id]: aLastSubject });
+const someSubjects = typedSubjects;
+const someMoreSubjects = { [aLastSubject.id]: aLastSubject };
 const anEntry = new Entry('label1', someSubjects, someResources);
 const anotherEntry = new Entry('label2', someMoreSubjects, someMoreResources);
 const typedEntries = { label1: anEntry, label2: anotherEntry };
-const entries = new Entries(typedEntries);
+const entries = typedEntries;
 const policy = new Policy('PolicyId', entries);
 
 const aSubjectObj = { type: aSubject.type };
@@ -84,13 +84,13 @@ describe('Resource', () => {
 describe('Resources', () => {
   it('parses an object', () => {
     expect(Resources.fromObject(someResourcesObj)).toEqual(someResources);
-    expect(Resources.fromObject(someResourcesObj).equals(someResources)).toBe(true);
+    expect(Resources.equals(Resources.fromObject(someResourcesObj), someResources)).toBe(true);
   });
   it('builds an object', () => {
-    expect(someResources.toObject()).toEqual(someResourcesObj);
+    expect(Resources.toObject(someResources)).toEqual(someResourcesObj);
   });
   it('returns its content', () => {
-    expect(someResources.resources).toEqual({ 'thing:/': aResource, 'thing:/attributes/some/path': anotherResource });
+    expect(someResources).toEqual({ 'thing:/': aResource, 'thing:/attributes/some/path': anotherResource });
   });
   it('handles an undefined object', () => {
     expect(Resources.fromObject(undefined)).toEqual(undefined);
@@ -117,13 +117,13 @@ describe('Subject', () => {
 describe('Subjects', () => {
   it('parses an object', () => {
     expect(Subjects.fromObject(someSubjectsObj)).toEqual(someSubjects);
-    expect(Subjects.fromObject(someSubjectsObj).equals(someSubjects)).toBe(true);
+    expect(Subjects.equals(Subjects.fromObject(someSubjectsObj), someSubjects)).toBe(true);
   });
   it('builds an object', () => {
-    expect(someSubjects.toObject()).toEqual(someSubjectsObj);
+    expect(Subjects.toObject(someSubjects)).toEqual(someSubjectsObj);
   });
   it('returns its content', () => {
-    expect(someSubjects.subjects).toEqual({ [aSubject.id]: aSubject, [anotherSubject.id]: anotherSubject });
+    expect(someSubjects).toEqual({ [aSubject.id]: aSubject, [anotherSubject.id]: anotherSubject });
   });
   it('handles an undefined object', () => {
     expect(Subjects.fromObject(undefined)).toEqual(undefined);
@@ -136,7 +136,7 @@ describe('Entry', () => {
     expect(Entry.fromObject(anEntryObj, 'label1').equals(anEntry)).toBe(true);
   });
   it('builds an object', () => {
-    expect(anEntry.toObject()).toEqual({ subjects: someSubjects.toObject(), resources: someResources.toObject() });
+    expect(anEntry.toObject()).toEqual({ subjects: Subjects.toObject(someSubjects), resources: Resources.toObject(someResources) });
   });
   it('returns its content', () => {
     expect(anEntry.id).toEqual('label1');
@@ -150,13 +150,13 @@ describe('Entry', () => {
 describe('Entries', () => {
   it('parses an object', () => {
     expect(Entries.fromObject(entriesObj)).toEqual(entries);
-    expect(Entries.fromObject(entriesObj).equals(entries)).toBe(true);
+    expect(Entries.equals(Entries.fromObject(entriesObj), entries)).toBe(true);
   });
   it('builds an object', () => {
-    expect(entries.toObject()).toEqual(entriesObj);
+    expect(Entries.toObject(entries)).toEqual(entriesObj);
   });
   it('returns its content', () => {
-    expect(entries.entries).toEqual({ label1: anEntry, label2: anotherEntry });
+    expect(entries).toEqual({ label1: anEntry, label2: anotherEntry });
   });
   it('handles an undefined object', () => {
     expect(Entries.fromObject(undefined)).toEqual(undefined);
@@ -172,7 +172,7 @@ describe('Policy', () => {
     expect(Policy.fromObject(policyObj, 'PolicyId').equals(policy)).toBe(true);
   });
   it('builds an object', () => {
-    expect(policy.toObject()).toEqual({ entries: entries.toObject() });
+    expect(policy.toObject()).toEqual({ entries: Entries.toObject(entries) });
   });
   it('returns its content', () => {
     expect(policy.id).toEqual('PolicyId');

--- a/javascript/lib/api/tests/model/things.model.spec.ts
+++ b/javascript/lib/api/tests/model/things.model.spec.ts
@@ -43,14 +43,15 @@ const responseObj = { items: [thingObj], nextPageOffset: 0 };
 const aFeature = new Feature('additionalProp1', aDefinition, someProperties);
 const anotherFeature = new Feature('additionalProp2', anotherDefinition, moreProperties);
 const typedFeatureObject = { additionalProp1: aFeature, additionalProp2: anotherFeature };
-const features = new Features(typedFeatureObject);
+const features = typedFeatureObject;
 const anAclEntry = new AclEntry('ID', true, true, true);
 const anotherAclEntry = new AclEntry('AnotherID', false, false, false);
-const acl = new Acl({ ID: anAclEntry, AnotherID: anotherAclEntry });
+const acl = { ID: anAclEntry, AnotherID: anotherAclEntry };
 const thing = new Thing('Testspace:Testthing', 'PolicyId', attributes, features, 0, '08042019', acl);
 const response = new SearchThingsResponse([thing], 0);
 
 describe('Feature', () => {
+
   it('parses an object', () => {
     expect(Feature.fromObject(aFeatureObj, 'additionalProp1')).toEqual(aFeature);
     expect(Feature.fromObject(aFeatureObj, 'additionalProp1').equals(aFeature)).toBe(true);
@@ -67,16 +68,17 @@ describe('Feature', () => {
     expect(Feature.fromObject(undefined, '')).toEqual(undefined);
   });
 });
+
 describe('Features', () => {
   it('parses an object', () => {
     expect(Features.fromObject(featuresObj)).toEqual(features);
-    expect(Features.fromObject(featuresObj).equals(features)).toBe(true);
+    expect(Features.equals(Features.fromObject(featuresObj), features)).toBe(true);
   });
   it('builds an object', () => {
-    expect(features.toObject()).toEqual(featuresObj);
+    expect(Features.toObject(features)).toEqual(featuresObj);
   });
   it('returns its content', () => {
-    expect(features.features).toEqual(typedFeatureObject);
+    expect(features).toEqual(typedFeatureObject);
   });
   it('handles an undefined object', () => {
     expect(Features.fromObject(undefined)).toEqual(undefined);
@@ -104,13 +106,13 @@ describe('AclEntry', () => {
 describe('Acl', () => {
   it('parses an object', () => {
     expect(Acl.fromObject(aclObj)).toEqual(acl);
-    expect(Acl.fromObject(aclObj).equals(acl)).toBe(true);
+    expect(Acl.equals(Acl.fromObject(aclObj), acl)).toBe(true);
   });
   it('builds an object', () => {
-    expect(acl.toObject()).toEqual(aclObj);
+    expect(Acl.toObject(acl)).toEqual(aclObj);
   });
   it('returns its content', () => {
-    expect(acl.aclEntries).toEqual({ [anAclEntry.id]: anAclEntry, [anotherAclEntry.id]: anotherAclEntry });
+    expect(acl).toEqual({ [anAclEntry.id]: anAclEntry, [anotherAclEntry.id]: anotherAclEntry });
   });
   it('handles an undefined object', () => {
     expect(Acl.fromObject(undefined)).toEqual(undefined);


### PR DESCRIPTION
Refactor model structure to avoid "duplicated paths" like `features.features` for all Entities inheriting form `IndexedEntityModel` and simplify type generics.
Classes where duplicated pahts were removed:
- `Features` 
- `Acl`
- `Entries`
- `Subjects`
- `Resources`

Fixes #114 