### PR TITLE
Fix serialization of booleans and numbers in filters

### DIFF
--- a/javascript/lib/api/src/model/things.model.ts
+++ b/javascript/lib/api/src/model/things.model.ts
@@ -60,8 +60,8 @@ export class Thing extends EntityWithId {
   }
 
   public toObject(): object {
-    const featuresObj = Features.toObject(this.features);
-    const aclObj = Acl.toObject(this._acl);
+    const featuresObj = this.features ? Features.toObject(this.features) : undefined;
+    const aclObj = this._acl ? Acl.toObject(this._acl) : undefined;
     return EntityModel.buildObject(new Map<string, any>([
       ['thingId', this.thingId],
       ['policyId', this.policyId],

--- a/javascript/lib/api/src/model/things.model.ts
+++ b/javascript/lib/api/src/model/things.model.ts
@@ -60,8 +60,8 @@ export class Thing extends EntityWithId {
   }
 
   public toObject(): object {
-    const featuresObj = this.features ? Features.toObject(this.features) : undefined;
-    const aclObj = this._acl ? Acl.toObject(this._acl) : undefined;
+    const featuresObj = Features.toObject(this.features);
+    const aclObj = Acl.toObject(this._acl);
     return EntityModel.buildObject(new Map<string, any>([
       ['thingId', this.thingId],
       ['policyId', this.policyId],

--- a/javascript/lib/api/src/options/filter.options.ts
+++ b/javascript/lib/api/src/options/filter.options.ts
@@ -154,7 +154,12 @@ export const Le: (property: string, value: any) => Filter =
  */
 export const In: (property: string, ...value: any[]) => Filter =
   (property: string, ...value: any[]) => {
-    return new DefaultFilter(`in(${property},${value.map(v => `"${v}"`).join()})`);
+    return new DefaultFilter(`in(${property},${value.map(v => {
+      if (typeof v === 'number' || typeof v === 'boolean') {
+        return `${v}`;
+      }
+      return `"${v}"`;
+    }).join()})`);
   };
 
 /**
@@ -204,9 +209,6 @@ const standardFilter: (operation: string, property: string, value: any) => Filte
   (operation: string, property: string, value: any) => {
     if (typeof value === 'boolean' || typeof value === 'number') {
       return new DefaultFilter(`${operation}(${property},${value})`);
-    }
-    if (typeof value === 'object') {
-      return new DefaultFilter(`${operation}(${property},${JSON.stringify(value)})`);
     }
     return new DefaultFilter(`${operation}(${property},"${value}")`);
   };

--- a/javascript/lib/api/src/options/filter.options.ts
+++ b/javascript/lib/api/src/options/filter.options.ts
@@ -200,7 +200,13 @@ const toList: (filter: Filter[]) => string =
  * @param value - The body to check for.
  * @return The Filter.
  */
-const standardFilter: (operation: string, property: string, value: string) => Filter =
-  (operation: string, property: string, value: string) => {
+const standardFilter: (operation: string, property: string, value: any) => Filter =
+  (operation: string, property: string, value: any) => {
+    if (typeof value === 'boolean' || typeof value === 'number') {
+      return new DefaultFilter(`${operation}(${property},${value})`);
+    }
+    if (typeof value === 'object') {
+      return new DefaultFilter(`${operation}(${property},${JSON.stringify(value)})`);
+    }
     return new DefaultFilter(`${operation}(${property},"${value}")`);
   };

--- a/javascript/lib/api/src/options/filter.options.ts
+++ b/javascript/lib/api/src/options/filter.options.ts
@@ -154,12 +154,7 @@ export const Le: (property: string, value: any) => Filter =
  */
 export const In: (property: string, ...value: any[]) => Filter =
   (property: string, ...value: any[]) => {
-    return new DefaultFilter(`in(${property},${value.map(v => {
-      if (typeof v === 'number' || typeof v === 'boolean') {
-        return `${v}`;
-      }
-      return `"${v}"`;
-    }).join()})`);
+    return new DefaultFilter(`in(${property},${value.map(stringify).join()})`);
   };
 
 /**
@@ -198,6 +193,25 @@ const toList: (filter: Filter[]) => string =
   };
 
 /**
+ * Returns a string representation that can be used as a filter value:
+ * number & boolean -> string representation
+ * object -> JSON string
+ * string -> string in quotes
+ *
+ * @param value The value of arbitrary type to stringify
+ */
+const stringify: (value: any) => string =
+  (value => {
+    if (typeof value === 'boolean' || typeof value === 'number') {
+      return value.toString();
+    }
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+    return `"${value}"`;
+  });
+
+/**
  * Standard operation for building Filters.
  *
  * @param operation - The type of Filter to build.
@@ -207,8 +221,5 @@ const toList: (filter: Filter[]) => string =
  */
 const standardFilter: (operation: string, property: string, value: any) => Filter =
   (operation: string, property: string, value: any) => {
-    if (typeof value === 'boolean' || typeof value === 'number') {
-      return new DefaultFilter(`${operation}(${property},${value})`);
-    }
-    return new DefaultFilter(`${operation}(${property},"${value}")`);
+    return new DefaultFilter(`${operation}(${property},${stringify(value)})`);
   };

--- a/javascript/lib/api/tests/options/filter.options.spec.ts
+++ b/javascript/lib/api/tests/options/filter.options.spec.ts
@@ -18,7 +18,6 @@ describe('Filters', () => {
   const prop = 'aProperty';
   const numberValue = 7;
   const stringValue = 'foobar';
-  const objectValue = { test: 'test' };
   const boolValue = false;
 
 
@@ -28,9 +27,6 @@ describe('Filters', () => {
 
     eq = Eq(prop, stringValue);
     expect(eq.toString()).toEqual(`eq(${prop},"${stringValue}")`);
-
-    eq = Eq(prop, objectValue);
-    expect(eq.toString()).toEqual(`eq(${prop},${JSON.stringify(objectValue)})`);
 
     eq = Eq(prop, boolValue);
     expect(eq.toString()).toEqual(`eq(${prop},${boolValue})`);
@@ -44,9 +40,6 @@ describe('Filters', () => {
     ne = Ne(prop, stringValue);
     expect(ne.toString()).toEqual(`ne(${prop},"${stringValue}")`);
 
-    ne = Ne(prop, objectValue);
-    expect(ne.toString()).toEqual(`ne(${prop},${JSON.stringify(objectValue)})`);
-
     ne = Ne(prop, boolValue);
     expect(ne.toString()).toEqual(`ne(${prop},${boolValue})`);
   });
@@ -57,9 +50,6 @@ describe('Filters', () => {
 
     gt = Gt(prop, stringValue);
     expect(gt.toString()).toEqual(`gt(${prop},"${stringValue}")`);
-
-    gt = Gt(prop, objectValue);
-    expect(gt.toString()).toEqual(`gt(${prop},${JSON.stringify(objectValue)})`);
 
     gt = Gt(prop, boolValue);
     expect(gt.toString()).toEqual(`gt(${prop},${boolValue})`);
@@ -72,9 +62,6 @@ describe('Filters', () => {
     ge = Ge(prop, stringValue);
     expect(ge.toString()).toEqual(`ge(${prop},"${stringValue}")`);
 
-    ge = Ge(prop, objectValue);
-    expect(ge.toString()).toEqual(`ge(${prop},${JSON.stringify(objectValue)})`);
-
     ge = Ge(prop, boolValue);
     expect(ge.toString()).toEqual(`ge(${prop},${boolValue})`);
 
@@ -85,9 +72,6 @@ describe('Filters', () => {
 
     lt = Lt(prop, stringValue);
     expect(lt.toString()).toEqual(`lt(${prop},"${stringValue}")`);
-
-    lt = Lt(prop, objectValue);
-    expect(lt.toString()).toEqual(`lt(${prop},${JSON.stringify(objectValue)})`);
 
     lt = Lt(prop, boolValue);
     expect(lt.toString()).toEqual(`lt(${prop},${boolValue})`);
@@ -100,16 +84,13 @@ describe('Filters', () => {
     le = Le(prop, stringValue);
     expect(le.toString()).toEqual(`le(${prop},"${stringValue}")`);
 
-    le = Le(prop, objectValue);
-    expect(le.toString()).toEqual(`le(${prop},${JSON.stringify(objectValue)})`);
-
     le = Le(prop, boolValue);
     expect(le.toString()).toEqual(`le(${prop},${boolValue})`);
   });
 
   it('builds an in', () => {
-    const inT = In(prop, numberValue, 'anotherOne');
-    expect(inT.toString()).toEqual(`in(${prop},"${numberValue}","anotherOne")`);
+    const inT = In(prop, numberValue, boolValue, stringValue, 'anotherOne');
+    expect(inT.toString()).toEqual(`in(${prop},${numberValue},${boolValue},"${stringValue}","anotherOne")`);
   });
 
   it('builds a like', () => {
@@ -138,9 +119,6 @@ describe('Filters', () => {
 
     not = Not(Eq(prop, stringValue));
     expect(not.toString()).toEqual(`not(eq(${prop},"${stringValue}"))`);
-
-    not = Not(Eq(prop, objectValue));
-    expect(not.toString()).toEqual(`not(eq(${prop},${JSON.stringify(objectValue)}))`);
 
     not = Not(Eq(prop, boolValue));
     expect(not.toString()).toEqual(`not(eq(${prop},${boolValue}))`);

--- a/javascript/lib/api/tests/options/filter.options.spec.ts
+++ b/javascript/lib/api/tests/options/filter.options.spec.ts
@@ -14,40 +14,109 @@
 import { And, Eq, Exists, Ge, Gt, In, Le, Like, Lt, Ne, Not, Or } from '../../src/options/filter.options';
 
 describe('Filters', () => {
+
   const prop = 'aProperty';
-  const value = 7;
+  const numberValue = 7;
+  const stringValue = 'foobar';
+  const objectValue = { test: 'test' };
+  const boolValue = false;
+
+
   it('builds an eq', () => {
-    const eq = Eq(prop, value);
-    expect(eq.toString()).toEqual(`eq(${prop},"${value}")`);
+    let eq = Eq(prop, numberValue);
+    expect(eq.toString()).toEqual(`eq(${prop},${numberValue})`);
+
+    eq = Eq(prop, stringValue);
+    expect(eq.toString()).toEqual(`eq(${prop},"${stringValue}")`);
+
+    eq = Eq(prop, objectValue);
+    expect(eq.toString()).toEqual(`eq(${prop},${JSON.stringify(objectValue)})`);
+
+    eq = Eq(prop, boolValue);
+    expect(eq.toString()).toEqual(`eq(${prop},${boolValue})`);
   });
+
+
   it('builds an ne', () => {
-    const ne = Ne(prop, value);
-    expect(ne.toString()).toEqual(`ne(${prop},"${value}")`);
+    let ne = Ne(prop, numberValue);
+    expect(ne.toString()).toEqual(`ne(${prop},${numberValue})`);
+
+    ne = Ne(prop, stringValue);
+    expect(ne.toString()).toEqual(`ne(${prop},"${stringValue}")`);
+
+    ne = Ne(prop, objectValue);
+    expect(ne.toString()).toEqual(`ne(${prop},${JSON.stringify(objectValue)})`);
+
+    ne = Ne(prop, boolValue);
+    expect(ne.toString()).toEqual(`ne(${prop},${boolValue})`);
   });
+
   it('builds a gt', () => {
-    const gt = Gt(prop, value);
-    expect(gt.toString()).toEqual(`gt(${prop},"${value}")`);
+    let gt = Gt(prop, numberValue);
+    expect(gt.toString()).toEqual(`gt(${prop},${numberValue})`);
+
+    gt = Gt(prop, stringValue);
+    expect(gt.toString()).toEqual(`gt(${prop},"${stringValue}")`);
+
+    gt = Gt(prop, objectValue);
+    expect(gt.toString()).toEqual(`gt(${prop},${JSON.stringify(objectValue)})`);
+
+    gt = Gt(prop, boolValue);
+    expect(gt.toString()).toEqual(`gt(${prop},${boolValue})`);
   });
+
   it('builds a ge', () => {
-    const ge = Ge(prop, value);
-    expect(ge.toString()).toEqual(`ge(${prop},"${value}")`);
+    let ge = Ge(prop, numberValue);
+    expect(ge.toString()).toEqual(`ge(${prop},${numberValue})`);
+
+    ge = Ge(prop, stringValue);
+    expect(ge.toString()).toEqual(`ge(${prop},"${stringValue}")`);
+
+    ge = Ge(prop, objectValue);
+    expect(ge.toString()).toEqual(`ge(${prop},${JSON.stringify(objectValue)})`);
+
+    ge = Ge(prop, boolValue);
+    expect(ge.toString()).toEqual(`ge(${prop},${boolValue})`);
+
   });
   it('builds a lt', () => {
-    const lt = Lt(prop, value);
-    expect(lt.toString()).toEqual(`lt(${prop},"${value}")`);
+    let lt = Lt(prop, numberValue);
+    expect(lt.toString()).toEqual(`lt(${prop},${numberValue})`);
+
+    lt = Lt(prop, stringValue);
+    expect(lt.toString()).toEqual(`lt(${prop},"${stringValue}")`);
+
+    lt = Lt(prop, objectValue);
+    expect(lt.toString()).toEqual(`lt(${prop},${JSON.stringify(objectValue)})`);
+
+    lt = Lt(prop, boolValue);
+    expect(lt.toString()).toEqual(`lt(${prop},${boolValue})`);
   });
+
   it('builds a le', () => {
-    const le = Le(prop, value);
-    expect(le.toString()).toEqual(`le(${prop},"${value}")`);
+    let le = Le(prop, numberValue);
+    expect(le.toString()).toEqual(`le(${prop},${numberValue})`);
+
+    le = Le(prop, stringValue);
+    expect(le.toString()).toEqual(`le(${prop},"${stringValue}")`);
+
+    le = Le(prop, objectValue);
+    expect(le.toString()).toEqual(`le(${prop},${JSON.stringify(objectValue)})`);
+
+    le = Le(prop, boolValue);
+    expect(le.toString()).toEqual(`le(${prop},${boolValue})`);
   });
+
   it('builds an in', () => {
-    const inT = In(prop, value, 'anotherOne');
-    expect(inT.toString()).toEqual(`in(${prop},"${value}","anotherOne")`);
+    const inT = In(prop, numberValue, 'anotherOne');
+    expect(inT.toString()).toEqual(`in(${prop},"${numberValue}","anotherOne")`);
   });
+
   it('builds a like', () => {
     const like = Like(prop, '*test*');
     expect(like.toString()).toEqual(`like(${prop},"*test*")`);
   });
+
   it('builds an exists', () => {
     const exists = Exists(prop);
     expect(exists.toString()).toEqual(`exists(${prop})`);
@@ -55,15 +124,26 @@ describe('Filters', () => {
 
   it('builds an and', () => {
     const and = And(Lt(prop, 7), Gt(prop, 5));
-    expect(and.toString()).toEqual(`and(lt(${prop},"7"),gt(${prop},"5"))`);
+    expect(and.toString()).toEqual(`and(lt(${prop},7),gt(${prop},5))`);
   });
+
   it('builds an or', () => {
     const or = Or(Lt(prop, 7), Gt(prop, 5));
-    expect(or.toString()).toEqual(`or(lt(${prop},"7"),gt(${prop},"5"))`);
+    expect(or.toString()).toEqual(`or(lt(${prop},7),gt(${prop},5))`);
   });
+
   it('builds a not', () => {
-    const not = Not(Lt(prop, 7));
-    expect(not.toString()).toEqual(`not(lt(${prop},"7"))`);
+    let not = Not(Lt(prop, 7));
+    expect(not.toString()).toEqual(`not(lt(${prop},7))`);
+
+    not = Not(Eq(prop, stringValue));
+    expect(not.toString()).toEqual(`not(eq(${prop},"${stringValue}"))`);
+
+    not = Not(Eq(prop, objectValue));
+    expect(not.toString()).toEqual(`not(eq(${prop},${JSON.stringify(objectValue)}))`);
+
+    not = Not(Eq(prop, boolValue));
+    expect(not.toString()).toEqual(`not(eq(${prop},${boolValue}))`);
   });
 
   it('builds big filters', () => {
@@ -84,7 +164,8 @@ describe('Filters', () => {
       )
     );
     expect(filter.toString())
-    // tslint:disable-next-line:max-line-length
-      .toEqual('and(or(ne(Prop1,"9"),gt(Prop2,"93")),or(like(Prop3,"*exp"),and(in(Prop4,"Option1","Option2"),le(Prop4,"Option3"))),not(eq(Prop5,"Option4")))');
+      // tslint:disable-next-line:max-line-length
+      .toEqual(
+        'and(or(ne(Prop1,9),gt(Prop2,93)),or(like(Prop3,"*exp"),and(in(Prop4,"Option1","Option2"),le(Prop4,"Option3"))),not(eq(Prop5,"Option4")))');
   });
 });

--- a/javascript/lib/api/tests/options/request.options.spec.ts
+++ b/javascript/lib/api/tests/options/request.options.spec.ts
@@ -111,7 +111,7 @@ describe('Count Options', () => {
   });
   it('sets filter', () => {
     countOptions.withFilter(And(Ne('Prop', 7)));
-    expect(countOptions.getOptions().get('filter')).toEqual(encodeURIComponent('and(ne(Prop,"7"))'));
+    expect(countOptions.getOptions().get('filter')).toEqual(encodeURIComponent('and(ne(Prop,7))'));
   });
   it('overrides filter', () => {
     countOptions.withFilter(And(Ne('Prop', 7)));
@@ -169,7 +169,7 @@ describe('Search Options', () => {
   });
   it('sets filter', () => {
     searchOptions.withFilter(And(Ne('Prop', 7)));
-    expect(searchOptions.getOptions().get('filter')).toEqual(encodeURIComponent('and(ne(Prop,"7"))'));
+    expect(searchOptions.getOptions().get('filter')).toEqual(encodeURIComponent('and(ne(Prop,7))'));
   });
   it('overrides filter', () => {
     searchOptions.withFilter(And(Ne('Prop', 7)));


### PR DESCRIPTION
This PR changes the way number and boolean values are "serialized" in filters. Previously, all values were put in quotation marks (""), but that leads to ditto parsing them wrong. 

Note that objecst might still be serialized as `[Object object]`, but as of my experiments it seems that ditto does not support filtering with a complex object anyways, so I see no value in adding a special case for this.

closes #123 