### PR TITLE
Adapt extracting of Live-Response from acknowledgement

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveImpl.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveImpl.java
@@ -352,8 +352,9 @@ public final class LiveImpl extends CommonManagementImpl<LiveThingHandle, LiveFe
         boolean handled = false;
 
         final ThingId thingId = liveCommand.getThingEntityId();
-        if (getFeatureIdFromResourcePath(liveCommand).isPresent()) {
-            final String featureId = getFeatureIdFromResourcePath(liveCommand).get().toString();
+        final Optional<JsonKey> featureIdFromResourcePath = getFeatureIdFromResourcePath(liveCommand);
+        if (featureIdFromResourcePath.isPresent()) {
+            final String featureId = featureIdFromResourcePath.get().toString();
             handled = getFeatureHandle(thingId, featureId)
                     .filter(h -> h instanceof LiveCommandProcessor)
                     .map(h -> (LiveCommandProcessor) h)


### PR DESCRIPTION
* live-response acknowledgement do now contain the payload of the
  message response in their payload.
* MessageHeaders are now part of the headers of the acknowledgement

This was done to fix a bug where a response could not get deserialized when it was negatively acknowledged by an exception in ditto (see: https://github.com/eclipse/ditto/pull/959)