### PR TITLE
Enhance Ditto java client with a "disconnection listener"

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/configuration/AccessTokenAuthenticationConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/AccessTokenAuthenticationConfiguration.java
@@ -164,7 +164,6 @@ public final class AccessTokenAuthenticationConfiguration extends AbstractAuthen
         @Override
         public AccessTokenAuthenticationConfigurationBuilder proxyConfiguration(
                 @Nullable final ProxyConfiguration proxyConfiguration) {
-
             this.proxyConfiguration = proxyConfiguration;
             return this;
         }

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/AccessTokenAuthenticationConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/AccessTokenAuthenticationConfiguration.java
@@ -31,20 +31,18 @@ import org.eclipse.ditto.client.messaging.JsonWebTokenSupplier;
  * @since 1.0.0
  */
 @Immutable
-public final class AccessTokenAuthenticationConfiguration extends AbstractAuthenticationConfiguration {
+public final class AccessTokenAuthenticationConfiguration extends AbstractAuthenticationConfiguration
+        implements TokenAuthenticationConfiguration {
 
     private final String identifier;
     private final JsonWebTokenSupplier jsonWebTokenSupplier;
     private final Duration expiryGracePeriod;
 
-    private AccessTokenAuthenticationConfiguration(final String identifier,
-            final JsonWebTokenSupplier jsonWebTokenSupplier,
-            final Duration expiryGracePeriod,
-            final Map<String, String> additionalHeaders) {
-        super(identifier, additionalHeaders, null);
-        this.identifier = identifier;
-        this.jsonWebTokenSupplier = jsonWebTokenSupplier;
-        this.expiryGracePeriod = expiryGracePeriod;
+    private AccessTokenAuthenticationConfiguration(final AccessTokenAuthenticationConfigurationBuilder builder) {
+        super(builder.identifier, builder.additionalHeaders, builder.proxyConfiguration);
+        this.identifier = builder.identifier;
+        this.jsonWebTokenSupplier = checkNotNull(builder.jsonWebTokenSupplier, "jsonWebTokenSupplier");
+        this.expiryGracePeriod = checkNotNull(builder.expiryGracePeriod, "expiryGracePeriod");
     }
 
     /**
@@ -63,20 +61,12 @@ public final class AccessTokenAuthenticationConfiguration extends AbstractAuthen
         return identifier;
     }
 
-    /**
-     * Returns the access token supplier.
-     *
-     * @return the supplier.
-     */
+    @Override
     public JsonWebTokenSupplier getJsonWebTokenSupplier() {
         return jsonWebTokenSupplier;
     }
 
-    /**
-     * Returns the grace period which will be subtracted from token expiry to trigger the configured token supplier.
-     *
-     * @return the grace period.
-     */
+    @Override
     public Duration getExpiryGracePeriod() {
         return expiryGracePeriod;
     }
@@ -108,7 +98,7 @@ public final class AccessTokenAuthenticationConfiguration extends AbstractAuthen
         return getClass().getSimpleName() + " [" +
                 super.toString() +
                 ", identifier=" + identifier +
-                ", accessTokenSupplier=" + jsonWebTokenSupplier +
+                ", jsonWebTokenSupplier=" + jsonWebTokenSupplier +
                 ", expiryGracePeriod=" + expiryGracePeriod +
                 "]";
     }
@@ -124,6 +114,7 @@ public final class AccessTokenAuthenticationConfiguration extends AbstractAuthen
         private String identifier;
         private JsonWebTokenSupplier jsonWebTokenSupplier;
         private Duration expiryGracePeriod = DEFAULT_EXPIRY_GRACE_PERIOD;
+        @Nullable private ProxyConfiguration proxyConfiguration;
 
         /**
          * Sets the identifier to authenticate.
@@ -168,14 +159,15 @@ public final class AccessTokenAuthenticationConfiguration extends AbstractAuthen
 
         @Override
         public AccessTokenAuthenticationConfigurationBuilder proxyConfiguration(
-                final ProxyConfiguration proxyConfiguration) {
+                @Nullable final ProxyConfiguration proxyConfiguration) {
+
+            this.proxyConfiguration = proxyConfiguration;
             return this;
         }
 
         @Override
         public AccessTokenAuthenticationConfiguration build() {
-            return new AccessTokenAuthenticationConfiguration(identifier, jsonWebTokenSupplier, expiryGracePeriod,
-                    additionalHeaders);
+            return new AccessTokenAuthenticationConfiguration(this);
         }
 
     }

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/AccessTokenAuthenticationConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/AccessTokenAuthenticationConfiguration.java
@@ -61,7 +61,11 @@ public final class AccessTokenAuthenticationConfiguration extends AbstractAuthen
         return identifier;
     }
 
-    @Override
+    /**
+     * Returns the grace period which will be subtracted from token expiry to trigger the configured token supplier.
+     *
+     * @return the grace period.
+     */
     public JsonWebTokenSupplier getJsonWebTokenSupplier() {
         return jsonWebTokenSupplier;
     }

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/ClientCredentialsAuthenticationConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/ClientCredentialsAuthenticationConfiguration.java
@@ -27,8 +27,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import org.eclipse.ditto.client.messaging.JsonWebTokenSupplier;
-
 /**
  * A {@link org.eclipse.ditto.client.configuration.AuthenticationConfiguration} for OAuth 2 client credentials
  * authentication.
@@ -43,7 +41,6 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
     private final String clientId;
     private final String clientSecret;
     private final List<String> scopes;
-    private final JsonWebTokenSupplier jsonWebTokenSupplier;
     private final Duration expiryGracePeriod;
 
     public ClientCredentialsAuthenticationConfiguration(
@@ -54,7 +51,6 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
         clientId = checkNotNull(builder.clientId, "clientId");
         clientSecret = checkNotNull(builder.clientSecret, "clientSecret");
         scopes = Collections.unmodifiableList(new ArrayList<>(builder.scopes));
-        jsonWebTokenSupplier = checkNotNull(builder.jsonWebTokenSupplier, "jsonWebTokenSupplier");
         expiryGracePeriod = checkNotNull(builder.expiryGracePeriod, "expiryGracePeriod");
     }
 
@@ -102,11 +98,6 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
     }
 
     @Override
-    public JsonWebTokenSupplier getJsonWebTokenSupplier() {
-        return jsonWebTokenSupplier;
-    }
-
-    @Override
     public Duration getExpiryGracePeriod() {
         return expiryGracePeriod;
     }
@@ -127,14 +118,12 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
                 Objects.equals(clientId, that.clientId) &&
                 Objects.equals(clientSecret, that.clientSecret) &&
                 Objects.equals(scopes, that.scopes) &&
-                Objects.equals(jsonWebTokenSupplier, that.jsonWebTokenSupplier) &&
                 Objects.equals(expiryGracePeriod, that.expiryGracePeriod);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), tokenEndpoint, clientId, clientSecret, scopes, jsonWebTokenSupplier,
-                expiryGracePeriod);
+        return Objects.hash(super.hashCode(), tokenEndpoint, clientId, clientSecret, scopes, expiryGracePeriod);
     }
 
     @Override
@@ -145,7 +134,6 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
                 ", clientId=" + clientId +
                 ", clientSecret=" + clientSecret +
                 ", scopes=" + scopes +
-                ", jsonWebTokenSupplier=" + jsonWebTokenSupplier +
                 ", expiryGracePeriod=" + expiryGracePeriod +
                 "]";
     }
@@ -160,7 +148,6 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
         private String clientId;
         private String clientSecret;
         private Collection<String> scopes;
-        private JsonWebTokenSupplier jsonWebTokenSupplier;
         private Duration expiryGracePeriod;
         @Nullable private ProxyConfiguration proxyConfiguration;
         private final Map<String, String> additionalHeaders;
@@ -213,18 +200,6 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
          */
         public ClientCredentialsAuthenticationConfigurationBuilder scopes(final Collection<String> scopes) {
             this.scopes = new ArrayList<>(checkNotNull(scopes, "scopes"));
-            return this;
-        }
-
-        /**
-         * Sets the access token supplier to authenticate.
-         *
-         * @param jsonWebTokenSupplier the supplier.
-         * @return this builder.
-         */
-        public ClientCredentialsAuthenticationConfigurationBuilder accessTokenSupplier(
-                final JsonWebTokenSupplier jsonWebTokenSupplier) {
-            this.jsonWebTokenSupplier = jsonWebTokenSupplier;
             return this;
         }
 

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/ClientCredentialsAuthenticationConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/ClientCredentialsAuthenticationConfiguration.java
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.client.messaging.JsonWebTokenSupplier;
+
 /**
  * A {@link org.eclipse.ditto.client.configuration.AuthenticationConfiguration} for OAuth 2 client credentials
  * authentication.
@@ -34,12 +36,14 @@ import javax.annotation.concurrent.NotThreadSafe;
  * @since 1.0.0
  */
 @Immutable
-public final class ClientCredentialsAuthenticationConfiguration extends AbstractAuthenticationConfiguration {
+public final class ClientCredentialsAuthenticationConfiguration extends AbstractAuthenticationConfiguration
+        implements TokenAuthenticationConfiguration {
 
     private final String tokenEndpoint;
     private final String clientId;
     private final String clientSecret;
     private final List<String> scopes;
+    private final JsonWebTokenSupplier jsonWebTokenSupplier;
     private final Duration expiryGracePeriod;
 
     public ClientCredentialsAuthenticationConfiguration(
@@ -50,6 +54,7 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
         clientId = checkNotNull(builder.clientId, "clientId");
         clientSecret = checkNotNull(builder.clientSecret, "clientSecret");
         scopes = Collections.unmodifiableList(new ArrayList<>(builder.scopes));
+        jsonWebTokenSupplier = checkNotNull(builder.jsonWebTokenSupplier, "jsonWebTokenSupplier");
         expiryGracePeriod = checkNotNull(builder.expiryGracePeriod, "expiryGracePeriod");
     }
 
@@ -96,11 +101,12 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
         return scopes;
     }
 
-    /**
-     * Returns the expiry grace period.
-     *
-     * @return the period.
-     */
+    @Override
+    public JsonWebTokenSupplier getJsonWebTokenSupplier() {
+        return jsonWebTokenSupplier;
+    }
+
+    @Override
     public Duration getExpiryGracePeriod() {
         return expiryGracePeriod;
     }
@@ -121,12 +127,14 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
                 Objects.equals(clientId, that.clientId) &&
                 Objects.equals(clientSecret, that.clientSecret) &&
                 Objects.equals(scopes, that.scopes) &&
+                Objects.equals(jsonWebTokenSupplier, that.jsonWebTokenSupplier) &&
                 Objects.equals(expiryGracePeriod, that.expiryGracePeriod);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), tokenEndpoint, clientId, clientSecret, scopes, expiryGracePeriod);
+        return Objects.hash(super.hashCode(), tokenEndpoint, clientId, clientSecret, scopes, jsonWebTokenSupplier,
+                expiryGracePeriod);
     }
 
     @Override
@@ -137,6 +145,7 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
                 ", clientId=" + clientId +
                 ", clientSecret=" + clientSecret +
                 ", scopes=" + scopes +
+                ", jsonWebTokenSupplier=" + jsonWebTokenSupplier +
                 ", expiryGracePeriod=" + expiryGracePeriod +
                 "]";
     }
@@ -151,6 +160,7 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
         private String clientId;
         private String clientSecret;
         private Collection<String> scopes;
+        private JsonWebTokenSupplier jsonWebTokenSupplier;
         private Duration expiryGracePeriod;
         @Nullable private ProxyConfiguration proxyConfiguration;
         private final Map<String, String> additionalHeaders;
@@ -158,7 +168,6 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
         private ClientCredentialsAuthenticationConfigurationBuilder() {
             scopes = Collections.emptyList();
             expiryGracePeriod = DEFAULT_EXPIRY_GRACE_PERIOD;
-            proxyConfiguration = null;
             additionalHeaders = new HashMap<>();
         }
 
@@ -204,6 +213,18 @@ public final class ClientCredentialsAuthenticationConfiguration extends Abstract
          */
         public ClientCredentialsAuthenticationConfigurationBuilder scopes(final Collection<String> scopes) {
             this.scopes = new ArrayList<>(checkNotNull(scopes, "scopes"));
+            return this;
+        }
+
+        /**
+         * Sets the access token supplier to authenticate.
+         *
+         * @param jsonWebTokenSupplier the supplier.
+         * @return this builder.
+         */
+        public ClientCredentialsAuthenticationConfigurationBuilder accessTokenSupplier(
+                final JsonWebTokenSupplier jsonWebTokenSupplier) {
+            this.jsonWebTokenSupplier = jsonWebTokenSupplier;
             return this;
         }
 

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/DisconnectedContext.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/DisconnectedContext.java
@@ -25,7 +25,7 @@ public interface DisconnectedContext {
     /**
      * Returns the {@link Source} providing the source of the disconnect.
      *
-     * @return the source of the disonnect.
+     * @return the source of the disconnect.
      */
     Source getSource();
 
@@ -101,4 +101,5 @@ public interface DisconnectedContext {
          */
         DisconnectionHandler performReconnect();
     }
+
 }

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/DisconnectedContext.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/DisconnectedContext.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.client.configuration;
+
+import java.util.Optional;
+
+/**
+ * Context provided to registered {@code disconnectedListener}s provided when building {@code MessagingConfiguration}
+ * of a new Ditto client instance.
+ *
+ * @since 2.1.0
+ */
+public interface DisconnectedContext {
+
+    /**
+     * Returns the {@link Source} providing the source of the disconnect.
+     *
+     * @return the source of the disonnect.
+     */
+    Source getSource();
+
+    /**
+     * Provides the optional cause (e.g. the last {@code DittoRuntimeException} or a websocket exception) before the
+     * disconnect.
+     *
+     * @return the optional cause of the disconnect.
+     */
+    Optional<Throwable> getCause();
+
+    /**
+     * Returns a {@link DisconnectionHandler} providing means to either destroy the client channel, prevent an automatic
+     * reconnect or to explicitly perform a reconnect.
+     *
+     * @return the disconnection handler providing options how to handle the disconnect.
+     */
+    DisconnectionHandler handleDisconnect();
+
+    /**
+     * An enumeration of the possible sources which initiated a disconnect.
+     */
+    enum Source {
+        /**
+         * The server closed the connection, potentially providing a cause before
+         * (sent as {@code DittoRuntimeException} wrapped in an error {@code Adaptable} before).
+         */
+        SERVER,
+
+        /**
+         * The client closed the connection - without request by the user code.
+         * This can e.g. happen if:
+         * <ul>
+         *   <li>authentication at the Ditto backend failed</li>
+         *   <li>an initialization or network error occurred (e.g. unknown/unresolvable host, proxy problems)</li>
+         *   <li>the WebSocket handshake with the provided Ditto backend endpoint failed</li>
+         * </ul>
+         */
+        CLIENT,
+
+        /**
+         * The user code explicitly disconnected.
+         */
+        USER_CODE
+    }
+
+    /**
+     * A handler provided to the user code providing options to handle an encountered disconnect.
+     */
+    interface DisconnectionHandler {
+
+        /**
+         * Closes the underlying channel (e.g. twin, live or policies channel) including their
+         * {@code MessagingProvider}.
+         *
+         * @return this instance for chaining.
+         */
+        DisconnectionHandler closeChannel();
+
+        /**
+         * Prevents the client from doing a (configured) automatic reconnect upon disconnection.
+         *
+         * @param preventReconnect whether to prevent the automatic reconnect or not.
+         * @return this instance for chaining.
+         */
+        DisconnectionHandler preventConfiguredReconnect(boolean preventReconnect);
+
+        /**
+         * Performs a reconnect independent from the configured automatic reconnect upon disconnection.
+         * Can e.g. be used to perform a reconnect only for certain disconnection sources or causes.
+         *
+         * @return this instance for chaining.
+         */
+        DisconnectionHandler performReconnect();
+    }
+}

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/MessagingConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/MessagingConfiguration.java
@@ -94,6 +94,13 @@ public interface MessagingConfiguration {
     Optional<Consumer<Throwable>> getConnectionErrorHandler();
 
     /**
+     * Returns the disconnected listener.
+     *
+     * @return the disconnected listener or an empty optional.
+     */
+    Optional<Consumer<DisconnectedContext>> getDisconnectedListener();
+
+    /**
      * Builder for creating an instance of {@code MessagingConfiguration} by utilizing Object Scoping and Method
      * Chaining.
      */
@@ -177,7 +184,15 @@ public interface MessagingConfiguration {
          * @param handler the handler that will be called with the cause of the connection error.
          * @since 1.2.0
          */
-        Builder connectionErrorHandler(@Nullable final Consumer<Throwable> handler);
+        Builder connectionErrorHandler(@Nullable Consumer<Throwable> handler);
+
+        /**
+         * Register a contextListener which is notified whenever the connection is disconnected.
+         *
+         * @param contextListener the handler that will be called with details about the disconnection.
+         * @since 2.1.0
+         */
+        Builder disconnectedListener(@Nullable Consumer<DisconnectedContext> contextListener);
 
         /**
          * Creates a new instance of {@code MessagingConfiguration}.

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/MessagingConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/MessagingConfiguration.java
@@ -152,7 +152,7 @@ public interface MessagingConfiguration {
         Builder reconnectEnabled(boolean reconnectEnabled);
 
         /**
-         * Sets if {@code initialConnectRetryEnbaled}.
+         * Sets if {@code initialConnectRetryEnabled}.
          * <p> Default is disabled. When establishing a new connection, the client doesn't try to reconnect.
          *
          * @param initialConnectRetryEnabled enables/disables retrying connection initialization.

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/TokenAuthenticationConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/TokenAuthenticationConfiguration.java
@@ -14,21 +14,12 @@ package org.eclipse.ditto.client.configuration;
 
 import java.time.Duration;
 
-import org.eclipse.ditto.client.messaging.JsonWebTokenSupplier;
-
 /**
  * Additional JWT / Token specific configurations.
  *
  * @since 2.1.0
  */
 public interface TokenAuthenticationConfiguration extends AuthenticationConfiguration {
-
-    /**
-     * Returns the access token supplier.
-     *
-     * @return the supplier.
-     */
-    JsonWebTokenSupplier getJsonWebTokenSupplier();
 
     /**
      * Returns the grace period which will be subtracted from token expiry to trigger the configured token supplier.

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/TokenAuthenticationConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/TokenAuthenticationConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.client.configuration;
+
+import java.time.Duration;
+
+import org.eclipse.ditto.client.messaging.JsonWebTokenSupplier;
+
+/**
+ * Additional JWT / Token specific configurations.
+ *
+ * @since 2.1.0
+ */
+public interface TokenAuthenticationConfiguration extends AuthenticationConfiguration {
+
+    /**
+     * Returns the access token supplier.
+     *
+     * @return the supplier.
+     */
+    JsonWebTokenSupplier getJsonWebTokenSupplier();
+
+    /**
+     * Returns the grace period which will be subtracted from token expiry to trigger the configured token supplier.
+     *
+     * @return the grace period.
+     */
+    Duration getExpiryGracePeriod();
+}

--- a/java/src/main/java/org/eclipse/ditto/client/configuration/TokenAuthenticationConfiguration.java
+++ b/java/src/main/java/org/eclipse/ditto/client/configuration/TokenAuthenticationConfiguration.java
@@ -27,4 +27,5 @@ public interface TokenAuthenticationConfiguration extends AuthenticationConfigur
      * @return the grace period.
      */
     Duration getExpiryGracePeriod();
+
 }

--- a/java/src/main/java/org/eclipse/ditto/client/internal/DefaultDittoClient.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/DefaultDittoClient.java
@@ -642,4 +642,5 @@ public final class DefaultDittoClient implements DittoClient, DisconnectedDittoC
                     ProtocolFactory.wrapAsJsonifiableAdaptable(adaptable).toJsonString());
         }
     }
+
 }

--- a/java/src/main/java/org/eclipse/ditto/client/internal/OutgoingMessageFactory.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/OutgoingMessageFactory.java
@@ -25,6 +25,11 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.DittoHeadersBuilder;
+import org.eclipse.ditto.base.model.headers.entitytag.EntityTagMatcher;
+import org.eclipse.ditto.base.model.headers.entitytag.EntityTagMatchers;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.client.live.messages.MessageSerializationException;
 import org.eclipse.ditto.client.live.messages.MessageSerializer;
 import org.eclipse.ditto.client.live.messages.MessageSerializerRegistry;
@@ -35,11 +40,6 @@ import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.headers.DittoHeadersBuilder;
-import org.eclipse.ditto.base.model.headers.entitytag.EntityTagMatcher;
-import org.eclipse.ditto.base.model.headers.entitytag.EntityTagMatchers;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.messages.model.Message;
 import org.eclipse.ditto.messages.model.MessageBuilder;
 import org.eclipse.ditto.messages.model.MessageHeaders;
@@ -47,16 +47,16 @@ import org.eclipse.ditto.messages.model.MessagesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyIdInvalidException;
+import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicy;
+import org.eclipse.ditto.policies.model.signals.commands.modify.DeletePolicy;
+import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicy;
+import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicy;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.FeatureDefinition;
 import org.eclipse.ditto.things.model.Features;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicy;
-import org.eclipse.ditto.policies.model.signals.commands.modify.DeletePolicy;
-import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicy;
-import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicy;
 import org.eclipse.ditto.things.model.signals.commands.modify.CreateThing;
 import org.eclipse.ditto.things.model.signals.commands.modify.DeleteAttribute;
 import org.eclipse.ditto.things.model.signals.commands.modify.DeleteAttributes;
@@ -87,6 +87,7 @@ import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThings;
  */
 public final class OutgoingMessageFactory {
 
+    private static final String ARGUMENT_THING = "thing";
     private static final EntityTagMatchers ASTERISK =
             EntityTagMatchers.fromList(Collections.singletonList(EntityTagMatcher.asterisk()));
 
@@ -141,7 +142,7 @@ public final class OutgoingMessageFactory {
      */
     public ModifyThing putThing(final Thing thing, @Nullable final JsonObject initialPolicy,
             final Option<?>... options) {
-        checkNotNull(thing, "thing");
+        checkNotNull(thing, ARGUMENT_THING);
         final ThingId thingId = thing.getEntityId().orElseThrow(() -> new IllegalArgumentException("Thing had no ID!"));
 
         validateOptions(initialPolicy, options);
@@ -165,7 +166,7 @@ public final class OutgoingMessageFactory {
      * @throws UnsupportedOperationException if an invalid option has been specified.
      */
     public ModifyThing updateThing(final Thing thing, final Option<?>... options) {
-        checkNotNull(thing, "thing");
+        checkNotNull(thing, ARGUMENT_THING);
         final ThingId thingId = thing.getEntityId().orElseThrow(() -> new IllegalArgumentException("Thing had no ID!"));
 
         final DittoHeaders headersWithoutIfMatch = buildDittoHeaders(false, options);
@@ -186,7 +187,7 @@ public final class OutgoingMessageFactory {
      * @throws UnsupportedOperationException if an invalid option has been specified.
      */
     MergeThing mergeThing(final ThingId thingId, final Thing thing, final Option<?>[] options) {
-        checkNotNull(thing, "thing");
+        checkNotNull(thing, ARGUMENT_THING);
 
         final DittoHeaders headersWithoutIfMatch = buildDittoHeaders(false, options);
         final DittoHeaders headers = headersWithoutIfMatch.toBuilder()

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/AdaptableBus.java
@@ -120,7 +120,7 @@ public interface AdaptableBus {
             Duration timeout,
             Consumer<Adaptable> adaptableConsumer,
             Predicate<Adaptable> terminationPredicate,
-            final Consumer<Throwable> onTimeout);
+            Consumer<Throwable> onTimeout);
 
     /**
      * Remove a subscription from the bus. Do nothing if the subscription ID is null.
@@ -136,9 +136,9 @@ public interface AdaptableBus {
     ScheduledExecutorService getScheduledExecutor();
 
     /**
-     * Closes the executor of the adaptable bus .
+     * Closes the executors of the adaptable bus.
      */
-    void shutdownExecutor();
+    void shutdownExecutors();
 
     /**
      * Publish a string message that may or may not be an adaptable.

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/BusFactory.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/BusFactory.java
@@ -12,10 +12,8 @@
  */
 package org.eclipse.ditto.client.internal.bus;
 
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
-
-import org.eclipse.ditto.client.messaging.MessagingProviders;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Factory for creating Buses (e.g. {@link PointerBus}).
@@ -43,15 +41,18 @@ public final class BusFactory {
      * Create an adaptable bus.
      *
      * @return the adaptable bus.
+     * @param defaultExecutor the default executor to run non-scheduled tasks on.
+     * @param scheduledExecutor the {@code ScheduledExecutorService} to use for scheduling tasks.
      */
-    public static AdaptableBus createAdaptableBus() {
-        final String name = "-adaptable-bus-" + UUID.randomUUID();
+    public static AdaptableBus createAdaptableBus(final ExecutorService defaultExecutor,
+            final ScheduledExecutorService scheduledExecutor) {
         // the executor service will shutdown when garbage-collected.
-        return new DefaultAdaptableBus(MessagingProviders.createScheduledExecutorService(name))
+        return new DefaultAdaptableBus(defaultExecutor, scheduledExecutor)
                 .addStringClassifier(Classifiers.identity())
                 .addAdaptableClassifier(Classifiers.correlationId())
                 .addAdaptableClassifier(Classifiers.streamingType())
                 .addAdaptableClassifier(Classifiers.thingsSearch())
+                .addAdaptableClassifier(Classifiers.errors())
                 .addAdaptableClassifier(Classifiers.errorCode());
     }
 }

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/Classification.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/Classification.java
@@ -71,6 +71,15 @@ public interface Classification {
     }
 
     /**
+     * Create an error classification key classifying all Ditto Protocol errors.
+     *
+     * @return the key.
+     */
+    static Classification forErrors() {
+        return new Errors();
+    }
+
+    /**
      * Create an error-code classification key.
      *
      * @param errorCode the error code.
@@ -200,6 +209,15 @@ public interface Classification {
 
         static <T> Optional<Classification> of(final T value) {
             return Optional.of(new Identity<>(value));
+        }
+    }
+
+    final class Errors extends Literal<String> {
+
+        private static final String ANY_ERROR = "";
+
+        private Errors() {
+            super(ANY_ERROR);
         }
     }
 

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/Classifiers.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/Classifiers.java
@@ -15,8 +15,8 @@ package org.eclipse.ditto.client.internal.bus;
 import java.util.EnumSet;
 import java.util.Optional;
 
-import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.protocol.Adaptable;
 import org.eclipse.ditto.protocol.TopicPath;
 import org.eclipse.ditto.thingsearch.model.signals.events.SubscriptionEvent;
@@ -65,6 +65,15 @@ public final class Classifiers {
      */
     public static Classifier<Adaptable> thingsSearch() {
         return Instances.THINGS_SEARCH_CLASSIFIER;
+    }
+
+    /**
+     * Classify all Ditto protocol errors.
+     *
+     * @return the errors classifier.
+     */
+    public static Classifier<Adaptable> errors() {
+        return Instances.ERRORS_CLASSIFIER;
     }
 
     /**
@@ -126,6 +135,18 @@ public final class Classifiers {
         }
     }
 
+    private static final class ErrorsClassifier implements Classifier<Adaptable> {
+
+        @Override
+        public Optional<Classification> classify(final Adaptable message) {
+            if (message.getTopicPath().getCriterion() == TopicPath.Criterion.ERRORS) {
+                return Optional.of(Classification.forErrors());
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
     private static final class ErrorCodeClassifier implements Classifier<Adaptable> {
 
         @Override
@@ -152,6 +173,8 @@ public final class Classifiers {
         private static final Classifier<Adaptable> STREAMING_TYPE_CLASSIFIER = new StreamingTypeClassifier();
 
         private static final Classifier<Adaptable> THINGS_SEARCH_CLASSIFIER = new ThingsSearchClassifier();
+
+        private static final Classifier<Adaptable> ERRORS_CLASSIFIER = new ErrorsClassifier();
 
         private static final Classifier<Adaptable> ERROR_CODE_CLASSIFIER = new ErrorCodeClassifier();
     }

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
@@ -104,15 +104,16 @@ final class DefaultAdaptableBus implements AdaptableBus {
             final Consumer<Adaptable> adaptableConsumer) {
         final Entry<Consumer<Adaptable>> entry = new Entry<>(tag, adaptableConsumer);
         addEntry(persistentAdaptableConsumers, entry);
+
         return entry;
     }
 
     @Override
     public SubscriptionId subscribeForAdaptableExclusively(final Classification tag,
             final Consumer<Adaptable> adaptableConsumer) {
-
         final Entry<Consumer<Adaptable>> entry = new Entry<>(tag, adaptableConsumer);
         replaceEntry(persistentAdaptableConsumers, entry);
+
         return entry;
     }
 
@@ -133,6 +134,7 @@ final class DefaultAdaptableBus implements AdaptableBus {
                     onTimeout.accept(timeoutError);
                     return null;
                 });
+
         return entry;
     }
 
@@ -259,8 +261,7 @@ final class DefaultAdaptableBus implements AdaptableBus {
         }
     }
 
-    private boolean publishToOneTimeAdaptableSubscribers(final Adaptable adaptable,
-            final List<Classification> tags) {
+    private boolean publishToOneTimeAdaptableSubscribers(final Adaptable adaptable, final List<Classification> tags) {
         for (final Classification tag : tags) {
             final Consumer<Adaptable> oneTimeSubscriber = removeOne(oneTimeAdaptableConsumers, tag);
             if (oneTimeSubscriber != null) {

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultAdaptableBus.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -51,8 +50,8 @@ final class DefaultAdaptableBus implements AdaptableBus {
     private static final String ACK_SUFFIX = ":ACK";
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAdaptableBus.class);
 
-    private final ExecutorService singleThreadedExecutorService;
-    private final ScheduledExecutorService scheduledExecutorService;
+    private final ExecutorService defaultExecutor;
+    private final ScheduledExecutorService scheduledExecutor;
     private final Collection<Classifier<String>> stringClassifiers;
     private final Collection<Classifier<Adaptable>> adaptableClassifiers;
 
@@ -61,9 +60,9 @@ final class DefaultAdaptableBus implements AdaptableBus {
     private final Map<Classification, Set<Entry<Consumer<Adaptable>>>> persistentAdaptableConsumers;
     private final Map<SubscriptionId, Future<?>> timeoutFutures;
 
-    DefaultAdaptableBus(final ScheduledExecutorService scheduledExecutorService) {
-        singleThreadedExecutorService = Executors.newSingleThreadExecutor();
-        this.scheduledExecutorService = scheduledExecutorService;
+    DefaultAdaptableBus(final ExecutorService defaultExecutor, final ScheduledExecutorService scheduledExecutor) {
+        this.defaultExecutor = defaultExecutor;
+        this.scheduledExecutor = scheduledExecutor;
         stringClassifiers = new ConcurrentLinkedQueue<>();
         adaptableClassifiers = new ConcurrentLinkedQueue<>();
         oneTimeStringConsumers = new ConcurrentHashMap<>();
@@ -152,25 +151,25 @@ final class DefaultAdaptableBus implements AdaptableBus {
 
     @Override
     public ScheduledExecutorService getScheduledExecutor() {
-        return scheduledExecutorService;
+        return scheduledExecutor;
     }
 
     @Override
     public void publish(final String message) {
-        singleThreadedExecutorService.submit(() -> doPublish(message));
+        doPublish(message);
     }
 
     @Override
-    public void shutdownExecutor() {
+    public void shutdownExecutors() {
         LOGGER.trace("Shutting down AdaptableBus Executors");
         try {
-            singleThreadedExecutorService.shutdownNow();
-            scheduledExecutorService.shutdownNow();
-            singleThreadedExecutorService.awaitTermination(2, TimeUnit.SECONDS);
-            scheduledExecutorService.awaitTermination(2, TimeUnit.SECONDS);
+            defaultExecutor.shutdownNow();
+            scheduledExecutor.shutdownNow();
+            defaultExecutor.awaitTermination(2, TimeUnit.SECONDS);
+            scheduledExecutor.awaitTermination(2, TimeUnit.SECONDS);
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOGGER.info("Waiting for termination was interrupted.");
+            LOGGER.info("Waiting for executors termination was interrupted.");
         }
     }
 
@@ -256,7 +255,7 @@ final class DefaultAdaptableBus implements AdaptableBus {
         if (tag.mustBeSequential()) {
             consumer.accept(message);
         } else {
-            scheduledExecutorService.submit(() -> consumer.accept(message));
+            defaultExecutor.submit(() -> consumer.accept(message));
         }
     }
 
@@ -307,7 +306,7 @@ final class DefaultAdaptableBus implements AdaptableBus {
             if (v != null) {
                 v.cancel(false);
             }
-            return scheduledExecutorService.schedule(runnable, when.toMillis(), TimeUnit.MILLISECONDS);
+            return scheduledExecutor.schedule(runnable, when.toMillis(), TimeUnit.MILLISECONDS);
         });
     }
 

--- a/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultPointerBus.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/bus/DefaultPointerBus.java
@@ -14,7 +14,6 @@ package org.eclipse.ditto.client.internal.bus;
 
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 /**
@@ -23,8 +22,6 @@ import java.util.function.Consumer;
  * @since 1.0.0
  */
 final class DefaultPointerBus implements PointerBus {
-
-    private static final int TERMINATION_TIMEOUT_SECONDS = 2;
 
     private final String name;
     private final ExecutorService executor;
@@ -59,12 +56,6 @@ final class DefaultPointerBus implements PointerBus {
     @Override
     public void close() {
         consumerRegistry.clear();
-        executor.shutdownNow();
-        try {
-            executor.awaitTermination(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
     }
 
     @Override

--- a/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveImpl.java
+++ b/java/src/main/java/org/eclipse/ditto/client/live/internal/LiveImpl.java
@@ -338,7 +338,7 @@ public final class LiveImpl extends CommonManagementImpl<LiveThingHandle, LiveFe
         if (thingId.isPresent() && featureIdFromResourcePath.isPresent()) {
             final String featureId = featureIdFromResourcePath.get().toString();
             handled = getFeatureHandle(thingId.get(), featureId)
-                    .filter(h -> h instanceof LiveCommandProcessor)
+                    .filter(LiveCommandProcessor.class::isInstance)
                     .map(LiveCommandProcessor.class::cast)
                     .map(h -> h.processLiveCommand(liveCommand))
                     .orElse(false);
@@ -348,7 +348,7 @@ public final class LiveImpl extends CommonManagementImpl<LiveThingHandle, LiveFe
 
         if (!handled && thingId.isPresent()) {
             handled = getThingHandle(thingId.get())
-                    .filter(h -> h instanceof LiveCommandProcessor)
+                    .filter(LiveCommandProcessor.class::isInstance)
                     .map(LiveCommandProcessor.class::cast)
                     .map(h -> h.processLiveCommand(liveCommand))
                     .orElse(false);

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProvider.java
@@ -136,4 +136,21 @@ public interface MessagingProvider {
      */
     void close();
 
+    /**
+     * Registers a {@code Runnable} to run when the user code performs a {@code closeChannel} in the disconnection
+     * handler of a registered disconnectionListener.
+     *
+     * @param channelCloser the runnable to ron
+     * @since 2.1.0
+     */
+    void registerChannelCloser(Runnable channelCloser);
+
+    /**
+     * Injects an error provided via Ditto Protocol message into the messaging provider in order to make it available
+     * to a user code provided {@code DisconnectedContext}.
+     *
+     * @param throwable the {@code DittoRuntimeException} or another throwable providing the error.
+     * @since 2.1.0
+     */
+    void onDittoProtocolError(Throwable throwable);
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProvider.java
@@ -140,7 +140,7 @@ public interface MessagingProvider {
      * Registers a {@code Runnable} to run when the user code performs a {@code closeChannel} in the disconnection
      * handler of a registered disconnectionListener.
      *
-     * @param channelCloser the runnable to ron
+     * @param channelCloser the runnable to run
      * @since 2.1.0
      */
     void registerChannelCloser(Runnable channelCloser);
@@ -153,4 +153,5 @@ public interface MessagingProvider {
      * @since 2.1.0
      */
     void onDittoProtocolError(Throwable throwable);
+
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProviders.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProviders.java
@@ -12,10 +12,12 @@
  */
 package org.eclipse.ditto.client.messaging;
 
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.ditto.client.configuration.MessagingConfiguration;
 import org.eclipse.ditto.client.internal.DefaultThreadFactory;
@@ -35,25 +37,98 @@ public final class MessagingProviders {
         throw new AssertionError("No instantiation.");
     }
 
+    /**
+     *  Creates a new {@code WebSocketMessagingProvider}.
+     *
+     * @param configuration configuration of websocket messaging.
+     * @param authenticationProvider provides authentication.
+     * @param defaultExecutor the executor for messages.
+     * @return the created WebSocket based MessagingProvider.
+     */
     public static MessagingProvider webSocket(final MessagingConfiguration configuration,
             final AuthenticationProvider<WebSocket> authenticationProvider,
-            final ExecutorService callbackExecutor) {
-        return WebSocketMessagingProvider.newInstance(configuration, authenticationProvider, callbackExecutor);
+            final ExecutorService defaultExecutor) {
+        final ScheduledExecutorService defaultScheduledExecutor = createScheduledExecutorService(
+                "abus-" + authenticationProvider.getConfiguration().getSessionId());
+        return WebSocketMessagingProvider.newInstance(configuration, authenticationProvider, defaultExecutor,
+                defaultScheduledExecutor);
     }
 
+    /**
+     * Creates a new {@code WebSocketMessagingProvider}.
+     *
+     * @param configuration configuration of websocket messaging.
+     * @param authenticationProvider provides authentication.
+     * @param callbackExecutor the executor for messages.
+     * @param internalBusExecutor the scheduled executor for the internal bus.
+     * @return the created WebSocket based MessagingProvider.
+     * @since 2.1.0
+     */
+    public static MessagingProvider webSocket(final MessagingConfiguration configuration,
+            final AuthenticationProvider<WebSocket> authenticationProvider,
+            final ExecutorService callbackExecutor,
+            final ScheduledExecutorService internalBusExecutor) {
+        return WebSocketMessagingProvider.newInstance(configuration, authenticationProvider, callbackExecutor,
+                internalBusExecutor);
+    }
+
+    /**
+     * Creates a new {@code WebSocketMessagingProvider} with default executors/thread pools.
+     *
+     * @param configuration configuration of websocket messaging.
+     * @param authenticationProvider provides authentication.
+     * @return the created WebSocket based MessagingProvider.
+     * @since 2.1.0
+     */
     public static MessagingProvider webSocket(final MessagingConfiguration configuration,
             final AuthenticationProvider<WebSocket> authenticationProvider) {
-        final ExecutorService defaultExecutorService = createDefaultExecutorService(UUID.randomUUID().toString());
-        return webSocket(configuration, authenticationProvider, defaultExecutorService);
+        final ExecutorService defaultCallbackExecutor = createDefaultExecutorService("default-" +
+                authenticationProvider.getConfiguration().getSessionId());
+        return webSocket(configuration, authenticationProvider, defaultCallbackExecutor);
     }
 
+    /**
+     * Creates the default {@code ExecutorService} the Ditto client uses if no other executor service was
+     * configured.
+     *
+     * @param name the name to use in the created threads.
+     * @return the default {@code ExecutorService}.
+     */
     public static ExecutorService createDefaultExecutorService(final String name) {
-        return createScheduledExecutorService(name);
+        return createExecutorService(name);
     }
 
+    /**
+     * Creates an {@code ExecutorService} backed by a {@code ThreadPoolExecutor} dynamic in thread size with 0 Threads
+     * core pool size and the maximum pool size depending on the available processors (times 8).
+     *
+     * @param name the name to use in the created threads.
+     * @return the default {@code ExecutorService}.
+     * @since 2.1.0
+     */
+    public static ExecutorService createExecutorService(final String name) {
+        final int maximumPoolSize = Runtime.getRuntime().availableProcessors() * 8; // limit by default to this max pool size
+        final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                0, maximumPoolSize, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
+                new DefaultThreadFactory("ditto-client-" + name),
+                new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.allowCoreThreadTimeOut(true);
+        return executor;
+    }
+
+    /**
+     * Creates a {@code ScheduledExecutorService} backed by a {@code ScheduledThreadPoolExecutor} dynamic in thread
+     * size with 0 Threads and an unbounded maximum pool size.
+     * <p>
+     * Only use for scheduling tasks in the future or at a fixed rate!
+     *
+     * @param name the name to use in the created threads.
+     * @return the {@code ScheduledExecutorService}.
+     */
     public static ScheduledExecutorService createScheduledExecutorService(final String name) {
-        final int corePoolSize = Runtime.getRuntime().availableProcessors() * 8;
-        return Executors.newScheduledThreadPool(corePoolSize, new DefaultThreadFactory("ditto-client-" + name));
+        // ScheduledThreadPool executor is by default unbounded in max size, so start with core-size of 0:
+        return Executors.newScheduledThreadPool(0,
+                new DefaultThreadFactory("ditto-client-scheduled-" + name));
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProviders.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/MessagingProviders.java
@@ -49,7 +49,7 @@ public final class MessagingProviders {
             final AuthenticationProvider<WebSocket> authenticationProvider,
             final ExecutorService defaultExecutor) {
         final ScheduledExecutorService defaultScheduledExecutor = createScheduledExecutorService(
-                "abus-" + authenticationProvider.getConfiguration().getSessionId());
+                "adaptable-bus-" + authenticationProvider.getConfiguration().getSessionId());
         return WebSocketMessagingProvider.newInstance(configuration, authenticationProvider, defaultExecutor,
                 defaultScheduledExecutor);
     }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/AbstractTokenAuthenticationProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/AbstractTokenAuthenticationProvider.java
@@ -47,10 +47,11 @@ abstract class AbstractTokenAuthenticationProvider implements AuthenticationProv
     private final JsonWebTokenSupplier jsonWebTokenSupplier;
     private final JwtRefreshScheduler jwtRefreshScheduler;
 
-    AbstractTokenAuthenticationProvider(final TokenAuthenticationConfiguration authenticationConfiguration) {
+    AbstractTokenAuthenticationProvider(final TokenAuthenticationConfiguration authenticationConfiguration,
+            final JsonWebTokenSupplier jsonWebTokenSupplier) {
         this.authenticationConfiguration = checkNotNull(authenticationConfiguration, "tokenAuthenticationConfiguration");
         this.additionalHeaders = authenticationConfiguration.getAdditionalHeaders();
-        this.jsonWebTokenSupplier = authenticationConfiguration.getJsonWebTokenSupplier();
+        this.jsonWebTokenSupplier = checkNotNull(jsonWebTokenSupplier, "jsonWebTokenSupplier");
         jwtRefreshScheduler = JwtRefreshScheduler.newInstance(jsonWebTokenSupplier,
                 authenticationConfiguration.getExpiryGracePeriod(), authenticationConfiguration.getSessionId());
     }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/AbstractTokenAuthenticationProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/AbstractTokenAuthenticationProvider.java
@@ -108,6 +108,7 @@ abstract class AbstractTokenAuthenticationProvider implements AuthenticationProv
             checkNotNull(jsonWebTokenSupplier, "jsonWebTokenSupplier");
             checkNotNull(expiryGracePeriod, "expiryGracePeriod");
             checkNotNull(sessionId, "sessionId");
+
             return new JwtRefreshScheduler(jsonWebTokenSupplier, expiryGracePeriod, sessionId);
         }
 

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/AccessTokenAuthenticationProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/AccessTokenAuthenticationProvider.java
@@ -22,7 +22,7 @@ import org.eclipse.ditto.client.configuration.AccessTokenAuthenticationConfigura
 public final class AccessTokenAuthenticationProvider extends AbstractTokenAuthenticationProvider {
 
     public AccessTokenAuthenticationProvider(final AccessTokenAuthenticationConfiguration configuration) {
-        super(configuration);
+        super(configuration, configuration.getJsonWebTokenSupplier());
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/AccessTokenAuthenticationProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/AccessTokenAuthenticationProvider.java
@@ -12,9 +12,6 @@
  */
 package org.eclipse.ditto.client.messaging.internal;
 
-import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
-
-import org.eclipse.ditto.client.configuration.AuthenticationConfiguration;
 import org.eclipse.ditto.client.configuration.AccessTokenAuthenticationConfiguration;
 
 /**
@@ -24,16 +21,8 @@ import org.eclipse.ditto.client.configuration.AccessTokenAuthenticationConfigura
  */
 public final class AccessTokenAuthenticationProvider extends AbstractTokenAuthenticationProvider {
 
-    private final AccessTokenAuthenticationConfiguration configuration;
-
     public AccessTokenAuthenticationProvider(final AccessTokenAuthenticationConfiguration configuration) {
-        super(configuration.getAdditionalHeaders(), configuration.getJsonWebTokenSupplier(), configuration.getExpiryGracePeriod());
-        this.configuration = checkNotNull(configuration, "configuration");
-    }
-
-    @Override
-    public AuthenticationConfiguration getConfiguration() {
-        return configuration;
+        super(configuration);
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/ClientCredentialsAuthenticationProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/ClientCredentialsAuthenticationProvider.java
@@ -22,7 +22,7 @@ import org.eclipse.ditto.client.configuration.ClientCredentialsAuthenticationCon
 public final class ClientCredentialsAuthenticationProvider extends AbstractTokenAuthenticationProvider {
 
     public ClientCredentialsAuthenticationProvider(final ClientCredentialsAuthenticationConfiguration configuration) {
-        super(configuration);
+        super(configuration, ClientCredentialsJsonWebTokenSupplier.newInstance(configuration));
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/ClientCredentialsAuthenticationProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/ClientCredentialsAuthenticationProvider.java
@@ -12,9 +12,6 @@
  */
 package org.eclipse.ditto.client.messaging.internal;
 
-import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
-
-import org.eclipse.ditto.client.configuration.AuthenticationConfiguration;
 import org.eclipse.ditto.client.configuration.ClientCredentialsAuthenticationConfiguration;
 
 /**
@@ -24,17 +21,8 @@ import org.eclipse.ditto.client.configuration.ClientCredentialsAuthenticationCon
  */
 public final class ClientCredentialsAuthenticationProvider extends AbstractTokenAuthenticationProvider {
 
-    private final ClientCredentialsAuthenticationConfiguration configuration;
-
     public ClientCredentialsAuthenticationProvider(final ClientCredentialsAuthenticationConfiguration configuration) {
-        super(configuration.getAdditionalHeaders(), ClientCredentialsJsonWebTokenSupplier.newInstance(configuration),
-                configuration.getExpiryGracePeriod());
-        this.configuration = checkNotNull(configuration, "configuration");
-    }
-
-    @Override
-    public AuthenticationConfiguration getConfiguration() {
-        return configuration;
+        super(configuration);
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/DefaultDisconnectedContext.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/DefaultDisconnectedContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.client.messaging.internal;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.client.configuration.DisconnectedContext;
+
+/**
+ * Default implementation of {@link DisconnectedContext}.
+ */
+final class DefaultDisconnectedContext implements DisconnectedContext {
+
+    private final Source source;
+    @Nullable private final Throwable throwable;
+    private final DisconnectionHandler disconnectionHandler;
+
+    DefaultDisconnectedContext(final Source source,
+            @Nullable final Throwable throwable,
+            final DisconnectionHandler disconnectionHandler) {
+        this.source = source;
+        this.throwable = throwable;
+        this.disconnectionHandler = disconnectionHandler;
+    }
+
+    @Override
+    public Source getSource() {
+        return source;
+    }
+
+    @Override
+    public Optional<Throwable> getCause() {
+        return Optional.ofNullable(throwable);
+    }
+
+    @Override
+    public DisconnectionHandler handleDisconnect() {
+        return disconnectionHandler;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "source=" + source +
+                ", throwable=" + throwable +
+                "]";
+    }
+
+}

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/Retry.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/Retry.java
@@ -304,6 +304,7 @@ final class Retry<T> {
                     checkNotNull(callbackExecutor, "callbackExecutor"),
                     errorConsumer, isRecoverable).completeFutureEventually(future);
         }
+
     }
 
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/Retry.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/Retry.java
@@ -47,8 +47,7 @@ final class Retry<T> {
     private final Supplier<CompletionStage<T>> retriedSupplier;
     private final ScheduledExecutorService reconnectExecutor;
     private final ExecutorService callbackExecutor;
-    @Nullable
-    private final Consumer<Throwable> errorConsumer;
+    @Nullable private final Consumer<Throwable> errorConsumer;
     private final Predicate<Throwable> isRecoverable;
 
     private Retry(final String nameOfAction,
@@ -198,8 +197,8 @@ final class Retry<T> {
          * @param callbackExecutor the executor to run callbacks on.
          * @return a new instance of this builder step.
          */
-        RetryBuilderFinal<T> withExecutors(final ScheduledExecutorService reconnectExecutor,
-                final ExecutorService callbackExecutor);
+        RetryBuilderFinal<T> withExecutors(ScheduledExecutorService reconnectExecutor,
+                ExecutorService callbackExecutor);
     }
 
     /**
@@ -214,7 +213,7 @@ final class Retry<T> {
          *
          * @param errorConsumer consumer which will be called with errors that happen during task to retry.
          */
-        RetryBuilderFinal<T> notifyOnError(@Nullable final Consumer<Throwable> errorConsumer);
+        RetryBuilderFinal<T> notifyOnError(@Nullable Consumer<Throwable> errorConsumer);
 
         /**
          * Test whether an exception can be recovered from.
@@ -224,7 +223,7 @@ final class Retry<T> {
          * @param isRecoverable whether the exception can be recovered from.
          * @return this builder.
          */
-        RetryBuilderFinal<T> isRecoverable(final Predicate<Throwable> isRecoverable);
+        RetryBuilderFinal<T> isRecoverable(Predicate<Throwable> isRecoverable);
 
         /**
          * Executes the provided supplier unit the supplier returns a result.
@@ -232,7 +231,7 @@ final class Retry<T> {
          * @param future the future to complete when the supplier returns a result.
          * @return A completion stage which finally completes with the result of the supplier. Result can be null.
          */
-        CompletionStage<T> completeFutureEventually(final CompletableFuture<T> future);
+        CompletionStage<T> completeFutureEventually(CompletableFuture<T> future);
     }
 
     /**

--- a/java/src/test/java/org/eclipse/ditto/client/ChangeUpwardsDownwardsPropagationTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/ChangeUpwardsDownwardsPropagationTest.java
@@ -25,6 +25,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.client.changes.Change;
 import org.eclipse.ditto.client.changes.ChangeAction;
 import org.eclipse.ditto.client.changes.FeaturesChange;
@@ -33,8 +35,6 @@ import org.eclipse.ditto.client.internal.AbstractDittoClientTest;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.messages.model.Message;
 import org.eclipse.ditto.messages.model.MessageDirection;
 import org.eclipse.ditto.messages.model.MessageHeaders;
@@ -313,8 +313,8 @@ public class ChangeUpwardsDownwardsPropagationTest extends AbstractDittoClientTe
                     assertThat(thingChange.isPartial()).isTrue();
                     assertThat((CharSequence) thingChange.getPath())
                             .isEqualTo(newPointer("attributes")); // attributes were changed
-                    assertThat(thingChange.getValue().get().toString()).isEqualTo(
-                            newObjectBuilder().set("attributes", attributesToSet).build().toString());
+                    assertThat(thingChange.getValue())
+                            .contains(newObjectBuilder().set("attributes", attributesToSet).build());
 
                     latch.countDown();
                 });
@@ -361,8 +361,8 @@ public class ChangeUpwardsDownwardsPropagationTest extends AbstractDittoClientTe
                             assertThat((CharSequence) thingChange.getPath())
                                     .isEqualTo(newPointer("attributes").append(
                                             newAttribute)); // single attributes was changed
-                            assertThat(thingChange.getValue().get().toString()).isEqualTo(
-                                    newObjectBuilder().set("attributes", buildObject).build().toString());
+                            assertThat(thingChange.getValue()).contains(
+                                    newObjectBuilder().set("attributes", buildObject).build());
 
                             latch.countDown();
                         });
@@ -440,8 +440,7 @@ public class ChangeUpwardsDownwardsPropagationTest extends AbstractDittoClientTe
             assertThat((CharSequence) featuresChange.getPath())
                     .isEqualTo(newPointer(FEATURE_ID_1).append(newPointer("properties"))
                             .append(fooPointer)); // feature property was created
-            assertThat(featuresChange.getValue().get().toString())
-                    .isEqualTo(expectedChangedObject.toString());
+            assertThat(featuresChange.getValue()).contains(expectedChangedObject);
 
             latch.countDown();
         };
@@ -495,8 +494,7 @@ public class ChangeUpwardsDownwardsPropagationTest extends AbstractDittoClientTe
                             assertThat((CharSequence) featureChange.getPath())
                                     .isEqualTo(newPointer("properties")
                                             .append(fooPointer)); // feature property was created
-                            assertThat(featureChange.getValue().get().toString())
-                                    .isEqualTo(expectedChangedObject.toString());
+                            assertThat(featureChange.getValue()).contains(expectedChangedObject);
 
                             latch.countDown();
                         });
@@ -536,8 +534,7 @@ public class ChangeUpwardsDownwardsPropagationTest extends AbstractDittoClientTe
                             assertThat(attrChange.isFull()).isTrue();
                             assertThat((CharSequence) attrChange.getPath())
                                     .isEqualTo(emptyPointer()); // empty pointer as all attributes were created
-                            assertThat(attrChange.getValue().get().toString())
-                                    .isEqualTo(ATTRIBUTES2.toJsonString());
+                            assertThat(attrChange.getValue()).contains(ATTRIBUTES2);
 
                             latch.countDown();
                         });

--- a/java/src/test/java/org/eclipse/ditto/client/configuration/internal/ClientCredentialsAuthenticationConfigurationTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/configuration/internal/ClientCredentialsAuthenticationConfigurationTest.java
@@ -12,10 +12,12 @@
  */
 package org.eclipse.ditto.client.configuration.internal;
 
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.client.configuration.ClientCredentialsAuthenticationConfiguration;
+import org.eclipse.ditto.client.messaging.JsonWebTokenSupplier;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -35,7 +37,8 @@ public final class ClientCredentialsAuthenticationConfigurationTest {
     @Test
     public void assertImmutability() {
         assertInstancesOf(ClientCredentialsAuthenticationConfiguration.class,
-                areImmutable());
+                areImmutable(),
+                provided(JsonWebTokenSupplier.class).isAlsoImmutable());
     }
 
 }

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/ClientCredentialsJsonWebTokenSupplierTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/ClientCredentialsJsonWebTokenSupplierTest.java
@@ -12,19 +12,22 @@
  */
 package org.eclipse.ditto.client.messaging.internal;
 
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import org.eclipse.ditto.client.configuration.ClientCredentialsAuthenticationConfiguration;
 import org.junit.Test;
 
 /**
- * Unit test for {@link org.eclipse.ditto.client.messaging.internal.ClientCredentialsJsonWebTokenSupplier}.
+ * Unit test for {@link ClientCredentialsJsonWebTokenSupplier}.
  */
-public final class JsonWebTokenSupplierTest {
+public final class ClientCredentialsJsonWebTokenSupplierTest {
 
     @Test
     public void assertImmutability() {
-        assertInstancesOf(ClientCredentialsJsonWebTokenSupplier.class, areImmutable());
+        assertInstancesOf(ClientCredentialsJsonWebTokenSupplier.class, areImmutable(),
+                provided(ClientCredentialsAuthenticationConfiguration.class).isAlsoImmutable());
     }
 
 }


### PR DESCRIPTION
* called whenever the connection to the Ditto backend was disconnected
* provides a context of who initiated the disconnection + an optional cause
* provides means to e.g. close the client as a result or to perform a reconnect

in addition: fixed executor service creation in Ditto: by default a ScheduledExecutorService with a high "corePoolSize" was configured as default
* only use "scheduled" exector for schedluded tasks
* provide Ditto client sessionId for thread factories (to append in thread names)
* make it possible to configure user code provided "scheduled" executor
