### PR TITLE
fixed that for Java Runtime 8, using corePoolSize 0 leads to CPU usage  of 100%

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/internal/VersionReader.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/VersionReader.java
@@ -60,4 +60,21 @@ public final class VersionReader {
     public static String determineBuildTimeStamp() {
         return PROPERTIES.getProperty(BUILD_DATE_PROPERTY_NAME, DEFAULT_VALUE);
     }
+
+    /**
+     * @return the Java major version number (e.g. 8,9,10,...) of the runtime the Ditto client runs in
+     */
+    public static int determineJavaRuntimeVersion() {
+        final String javaVersion = System.getProperty("java.version");
+        if (javaVersion.startsWith("1.")) {
+            return Integer.parseInt(javaVersion.substring(2, 3));
+        } else {
+            final int dot = javaVersion.indexOf(".");
+            if (dot != -1) {
+                return Integer.parseInt(javaVersion.substring(0, dot));
+            } else {
+                return 0;
+            }
+        }
+    }
 }

--- a/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
+++ b/java/src/main/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProvider.java
@@ -153,7 +153,15 @@ public final class WebSocketMessagingProvider extends WebSocketAdapter implement
     }
 
     private static ScheduledExecutorService createConnectExecutor(final String sessionId) {
-        return Executors.newScheduledThreadPool(0,
+        final int corePoolSize;
+        if (VersionReader.determineJavaRuntimeVersion() <= 8) {
+            // for Java <= 8, because of bug https://bugs.openjdk.java.net/browse/JDK-8129861, the corePoolSize must be at least 1:
+            corePoolSize = 1;
+        } else {
+            // bug has been fixed since Java 9, so scale down to 0 threads if the scheduledThreadPool is not needed:
+            corePoolSize = 0;
+        }
+        return Executors.newScheduledThreadPool(corePoolSize,
                 new DefaultThreadFactory("ditto-client-reconnect-" + sessionId));
     }
 


### PR DESCRIPTION
* known bug for Java 8: https://bugs.openjdk.java.net/browse/JDK-8129861
* use corePoolSize 0 for a Java Runtime > 8