### PR TITLE
Added option for live channel condition.

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/management/CommonManagement.java
+++ b/java/src/main/java/org/eclipse/ditto/client/management/CommonManagement.java
@@ -130,10 +130,12 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
     /**
      * Creates an empty {@link Thing} with an auto-generated identifier.
      *
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the created Thing object or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code options} contains an option
+     * that is not allowed for creating a thing.
      */
     CompletionStage<Thing> create(Option<?>... options);
 
@@ -142,11 +144,13 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      *
      * @param thingId the identifier of the Thing to be created. It must conform to the namespaced
      * entity ID notation (see Ditto documentation).
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code thingId} is {@code null} or empty.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the created Thing object or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code thingId} is {@code null} or empty
+     * or if {@code options} contains an option that is not allowed for
+     * creating a thing.
      * @throws org.eclipse.ditto.things.model.ThingIdInvalidException if the {@code thingId} was invalid.
      */
     CompletionStage<Thing> create(ThingId thingId, Option<?>... options);
@@ -155,11 +159,13 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * Creates the given {@link Thing}.
      *
      * @param thing the Thing to be created.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier.
+     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier
+     * or if {@code options} contains an option that is not allowed for
+     * creating a thing.
      * @throws org.eclipse.ditto.things.model.ThingIdInvalidException if the {@code thingId} was invalid.
      */
     CompletionStage<Thing> create(Thing thing, Option<?>... options);
@@ -172,10 +178,10 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * to be created. It must conform to the namespaced entity ID notation (see Ditto documentation).
      * @param options options to be applied configuring behaviour of this method, see
      * {@link org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @return CompletionStage providing the created Thing object or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or if it does not contain the field named
-     * {@code "thingId"}.
+     * {@code "thingId"} or if {@code options} contains an option that is not allowed for creating a thing.
      * @throws org.eclipse.ditto.base.model.exceptions.DittoJsonException if {@code thing} cannot be parsed to a
      * {@link Thing}.
      * @throws org.eclipse.ditto.things.model.ThingIdInvalidException if the {@code thingId} was invalid.
@@ -184,13 +190,15 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
     CompletionStage<Thing> create(JsonObject thing, Option<?>... options);
 
     /**
-     * Creates an empty {@link Thing} with an auto-generated identifier as well as an initial Policy
+     * Creates an empty {@link Thing} with an auto-generated identifier as well as an initial Policy.
      *
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the created Thing object or a specific
+     * @throws IllegalArgumentException if {@code options} contains an option
+     * that is not allowed for creating a thing.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @since 1.1.0
      */
     CompletionStage<Thing> create(Policy initialPolicy, Option<?>... options);
@@ -200,12 +208,13 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      *
      * @param thing the Thing to be created.
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the created Thing object or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier, or if
-     * {@code initialPolicy} is {@code null}.
+     * {@code initialPolicy} is {@code null} or if {@code options} contains an option
+     * that is not allowed for creating a thing.
      * @throws org.eclipse.ditto.things.model.ThingIdInvalidException if the {@code thingId} was invalid.
      * @since 1.1.0
      */
@@ -217,12 +226,12 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * @param thingId the identifier of the Thing to be created. It must conform to the namespaced
      * entity ID notation (see Ditto documentation).
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the created Thing object or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thingId} is {@code null} or empty, or if {@code initialPolicy} is
-     * {@code null}.
+     * {@code null} or if {@code options} contains an option that is not allowed for creating a thing.
      * @throws org.eclipse.ditto.things.model.ThingIdInvalidException if the {@code thingId} was invalid.
      * @since 1.1.0
      */
@@ -235,14 +244,15 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * contain a field named {@code "thingId"} of the basic JSON type String which contains the identifier of the Thing
      * to be created. It must conform to the namespaced entity ID notation (see Ditto documentation).
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the created Thing object or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or if it does not contain the field named
-     * {@code "thingId"}, or if {@code initialPolicy} is {@code null}.
-     * @throws org.eclipse.ditto.base.model.exceptions.DittoJsonException if {@code thing} cannot be parsed to a {@link
-     * Thing}.
+     * {@code "thingId"}, or if {@code initialPolicy} is {@code null} or if {@code options} contains an option that
+     * is not allowed for creating a thing.
+     * @throws org.eclipse.ditto.base.model.exceptions.DittoJsonException if {@code thing} cannot be parsed to a
+     * {@link Thing}.
      * @throws org.eclipse.ditto.things.model.ThingIdInvalidException if the {@code thingId} was invalid.
      * @since 1.1.0
      */
@@ -253,12 +263,13 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      *
      * @param thing the Thing to be created.
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the created Thing object or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier, or if
-     * {@code initialPolicy} is {@code null}.
+     * {@code initialPolicy} is {@code null} or if {@code options} contains an option that
+     * is not allowed for creating a thing.
      * @throws org.eclipse.ditto.things.model.ThingIdInvalidException if the {@code thingId} was invalid.
      * @since 1.1.0
      */
@@ -270,12 +281,12 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * @param thingId the identifier of the Thing to be created. It must conform to the namespaced
      * entity ID notation (see Ditto documentation).
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the created Thing object or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thingId} is {@code null} or empty, or if {@code initialPolicy} is
-     * {@code null}.
+     * {@code null} or if {@code options} contains an option that is not allowed for creating a thing.
      * @throws org.eclipse.ditto.things.model.ThingIdInvalidException if the {@code thingId} was invalid.
      * @since 1.1.0
      */
@@ -288,14 +299,15 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * contain a field named {@code "thingId"} of the basic JSON type String which contains the identifier of the Thing
      * to be created. It must conform to the namespaced entity ID notation (see Ditto documentation).
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing the created Thing object or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the created Thing object or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or if it does not contain the field named
-     * {@code "thingId"}, or if {@code initialPolicy} is {@code null}.
-     * @throws org.eclipse.ditto.base.model.exceptions.DittoJsonException if {@code thing} cannot be parsed to a {@link
-     * Thing}.
+     * {@code "thingId"}, or if {@code initialPolicy} is {@code null} or if {@code options} contains an option that
+     * is not allowed for creating a thing.
+     * @throws org.eclipse.ditto.base.model.exceptions.DittoJsonException if {@code thing} cannot be parsed to a
+     * {@link Thing}.
      * @throws org.eclipse.ditto.things.model.ThingIdInvalidException if the {@code thingId} was invalid.
      * @since 1.1.0
      */
@@ -306,11 +318,12 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      *
      * @param thingId the Thing to be merged.
      * @param thing which should be used for merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return completable future providing {@code null} in case of success or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
-     * @throws IllegalArgumentException if {@code argument} is {@code null}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return completable future providing {@code null} in case of success or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code argument} is {@code null} or if {@code options} contains an option
+     * that is not allowed for merging a thing.
      * @since 2.0.0
      */
     CompletionStage<Void> merge(ThingId thingId, Thing thing, Option<?>... options);
@@ -320,11 +333,12 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      *
      * @param thingId the Thing to be merged.
      * @param thing a JSON object representation of the Thing which should be used for merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return completable future providing {@code null} in case of success or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
-     * @throws IllegalArgumentException if {@code argument} is {@code null}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return completable future providing {@code null} in case of success or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code argument} is {@code null} or if {@code options} contains an option
+     * that is not allowed for merging a thing.
      * @since 2.0.0
      */
     CompletionStage<Void> merge(ThingId thingId, JsonObject thing, Option<?>... options);
@@ -334,30 +348,32 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * restricted with option {@link org.eclipse.ditto.client.options.Options.Modify#exists(boolean)}.
      *
      * @param thing the Thing to be put.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage providing an {@link Optional} containing the created Thing object, in case the Thing
-     * has been created, or an empty Optional, in case the Thing has been updated. Provides a {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
-     * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier.
+     * has been created, or an empty Optional, in case the Thing has been updated. Provides a
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier or if {@code options}
+     * contains an option that is not allowed for putting a thing.
      * @since 1.0.0
      */
     CompletionStage<Optional<Thing>> put(Thing thing, Option<?>... options);
 
     /**
      * Puts a {@link Thing} based on the given {@link JsonObject}, which means that the Thing might be created or
-     * updated. The behaviour can be restricted with option {@link org.eclipse.ditto.client.options.Options.Modify#exists(boolean)}.
+     * updated. The behaviour can be restricted with option
+     * {@link org.eclipse.ditto.client.options.Options.Modify#exists(boolean)}.
      *
      * @param thing a JSON object representation of the Thing to be put. The provided JSON object is required to contain
      * a field named {@code "thingId"} of the basic JSON type String which contains the identifier of the Thing to be
      * put.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage providing an {@link Optional} containing the created Thing object, in case the Thing
-     * has been created, or an empty Optional, in case the Thing has been updated. Provides a {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * has been created, or an empty Optional, in case the Thing has been updated. Provides a
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or if it does not contain the field named
-     * {@code "thingId"}.
+     * {@code "thingId"} or if {@code options} contains an option that is not allowed for putting a thing.
      * @throws org.eclipse.ditto.base.model.exceptions.DittoJsonException if {@code thing} cannot be parsed to a
      * {@link Thing}.
      * @since 1.0.0
@@ -371,13 +387,14 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * @param thing the Thing to be put.
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy. This will only apply if
      * the Thing does not already exist.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage providing an {@link Optional} containing the created Thing object, in case the Thing
-     * has been created, or an empty Optional, in case the Thing has been updated. Provides a {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * has been created, or an empty Optional, in case the Thing has been updated. Provides a
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier, or if
-     * {@code initialPolicy} is {@code null}.
+     * {@code initialPolicy} is {@code null} or if {@code options} contains an option that is not allowed for putting
+     * a thing.
      * @since 1.1.0
      */
     CompletionStage<Optional<Thing>> put(Thing thing, JsonObject initialPolicy, Option<?>... options);
@@ -391,13 +408,14 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * put.
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy. This will only apply if
      * the Thing does not already exist.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage providing an {@link Optional} containing the created Thing object, in case the Thing
-     * has been created, or an empty Optional, in case the Thing has been updated. Provides a {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * has been created, or an empty Optional, in case the Thing has been updated. Provides a
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or if it does not contain the field named
-     * {@code "thingId"}, or if {@code initialPolicy} is {@code null}.
+     * {@code "thingId"}, or if {@code initialPolicy} is {@code null} or if {@code options} contains an option that is
+     * not allowed for putting a thing.
      * @throws org.eclipse.ditto.base.model.exceptions.DittoJsonException if {@code thing} cannot be parsed to a
      * {@link Thing}.
      * @since 1.1.0
@@ -411,13 +429,14 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * @param thing the Thing to be put.
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy. This will only apply if
      * the Thing does not already exist.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage providing an {@link Optional} containing the created Thing object, in case the Thing
-     * has been created, or an empty Optional, in case the Thing has been updated. Provides a {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * has been created, or an empty Optional, in case the Thing has been updated. Provides a
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier, or if
-     * {@code initialPolicy} is {@code null}.
+     * {@code initialPolicy} is {@code null} or if {@code options} contains an option that is
+     * not allowed for putting a thing.
      * @since 1.1.0
      */
     CompletionStage<Optional<Thing>> put(Thing thing, Policy initialPolicy, Option<?>... options);
@@ -432,13 +451,14 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * put.
      * @param initialPolicy a custom policy to use for the Thing instead of the default Policy. This will only apply if
      * the Thing does not already exist.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage providing an {@link Optional} containing the created Thing object, in case the Thing
-     * has been created, or an empty Optional, in case the Thing has been updated. Provides a {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * has been created, or an empty Optional, in case the Thing has been updated. Provides a
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or if it does not contain the field named
-     * {@code "thingId"}, or if {@code initialPolicy} is {@code null}.
+     * {@code "thingId"}, or if {@code initialPolicy} is {@code null} or if {@code options} contains an option that is
+     * not allowed for putting a thing.
      * @throws org.eclipse.ditto.base.model.exceptions.DittoJsonException if {@code thing} cannot be parsed to a
      * {@link Thing}.
      * @since 1.1.0
@@ -449,11 +469,12 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * Updates the given {@link Thing} if it does exist.
      *
      * @param thing the Thing to be updated.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing {@code null} in case of success or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
-     * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing {@code null} in case of success or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code thing} is {@code null} or has no identifier
+     * or if {@code options} contains an option that is not allowed for updating a thing.
      */
     CompletionStage<Void> update(Thing thing, Option<?>... options);
 
@@ -463,12 +484,12 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * @param thing a JSON object representation of the Thing to be updated. The provided JSON object is required to
      * contain a field named {@code "thingId"} of the basic JSON type String which contains the identifier of the Thing
      * to be updated.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage providing {@code null} in case of success or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing {@code null} in case of success or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if {@code thing} is {@code null} or if it does not contain the field named
-     * {@code "thingId"}.
+     * {@code "thingId"} or if {@code options} contains an option that is not allowed for updating a thing.
      * @throws org.eclipse.ditto.base.model.exceptions.DittoJsonException if {@code thing} cannot be parsed to a
      * {@link Thing}.
      */
@@ -478,11 +499,12 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * Deletes the {@link Thing} specified by the given identifier.
      *
      * @param thingId the identifier of the Thing to be deleted.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage for handling the result of deletion or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code thingId} is {@code null}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage for handling the result of deletion or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code thingId} is {@code null} or if {@code options} contains an option
+     * that is not allowed for updating a thing.
      */
     CompletionStage<Void> delete(ThingId thingId, Option<?>... options);
 
@@ -492,8 +514,8 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      *
      * @param thingId the first identifier of the Thing to be retrieved.
      * @param thingIds additional identifiers of Things to be retrieved.
-     * @return CompletionStage providing the requested Things, an empty list or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @return CompletionStage providing the requested Things, an empty list or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if any argument is {@code null}.
      */
     CompletionStage<List<Thing>> retrieve(ThingId thingId, ThingId... thingIds);
@@ -505,8 +527,8 @@ public interface CommonManagement<T extends ThingHandle, F extends FeatureHandle
      * @param fieldSelector a field selector allowing to select a subset of fields on the Things to be retrieved.
      * @param thingId the first identifier of the Thing to be retrieved.
      * @param thingIds additional identifiers of Things to be retrieved.
-     * @return CompletionStage providing the requested Things, an empty list or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @return CompletionStage providing the requested Things, an empty list or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws IllegalArgumentException if any argument is {@code null}.
      */
     CompletionStage<List<Thing>> retrieve(JsonFieldSelector fieldSelector, ThingId thingId, ThingId... thingIds);

--- a/java/src/main/java/org/eclipse/ditto/client/management/FeatureDefinitionManagement.java
+++ b/java/src/main/java/org/eclipse/ditto/client/management/FeatureDefinitionManagement.java
@@ -40,6 +40,8 @@ public interface FeatureDefinitionManagement {
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for setting
+     * a feature definition.
      */
     CompletionStage<Void> setDefinition(FeatureDefinition definition, Option<?>... options);
 
@@ -52,6 +54,8 @@ public interface FeatureDefinitionManagement {
      * @return a CompletionStage providing the result of this operation or a specific {@link
      * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for merging
+     * a feature definition.
      * @since 2.0.0
      */
     CompletionStage<Void> mergeDefinition(FeatureDefinition definition, Option<?>... options);
@@ -63,6 +67,8 @@ public interface FeatureDefinitionManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for deleting
+     * a feature definition.
      */
     CompletionStage<Void> deleteDefinition(Option<?>... options);
 

--- a/java/src/main/java/org/eclipse/ditto/client/management/FeatureHandle.java
+++ b/java/src/main/java/org/eclipse/ditto/client/management/FeatureHandle.java
@@ -55,6 +55,8 @@ public interface FeatureHandle extends WithFeatureId, FeaturePropertiesManagemen
      * @param options options to be applied configuring behaviour of this method, see
      * {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for deleting a
+     * feature.
      */
     CompletionStage<Void> delete(Option<?>... options);
 
@@ -74,6 +76,8 @@ public interface FeatureHandle extends WithFeatureId, FeaturePropertiesManagemen
      * @return CompletionStage providing the requested Feature object, when completed successfully or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws NullPointerException if {@code options} is {@code null}.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for retrieving a
+     * feature.
      * @since 2.1.0
      */
     CompletionStage<Feature> retrieve(Option<?>... options);
@@ -98,6 +102,8 @@ public interface FeatureHandle extends WithFeatureId, FeaturePropertiesManagemen
      * @return CompletionStage providing the requested Feature object, when completed successfully or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for retrieving a
+     * feature.
      * @since 2.1.0
      */
     CompletionStage<Feature> retrieve(JsonFieldSelector fieldSelector, Option<?>... options);

--- a/java/src/main/java/org/eclipse/ditto/client/management/FeaturePropertiesManagement.java
+++ b/java/src/main/java/org/eclipse/ditto/client/management/FeaturePropertiesManagement.java
@@ -43,12 +43,14 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
-    default CompletionStage<Void> putProperty(final CharSequence path, final boolean value,
+    default CompletionStage<Void> putProperty(final CharSequence path,
+            final boolean value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return putProperty(JsonFactory.newPointer(path), value, options);
+
+        return putProperty(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -60,7 +62,8 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
     CompletionStage<Void> putProperty(JsonPointer path, boolean value, Option<?>... options);
 
@@ -74,12 +77,11 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
-    default CompletionStage<Void> putProperty(final CharSequence path, final double value,
-            final Option<?>... options) {
-        argumentNotNull(path);
-        return putProperty(JsonFactory.newPointer(path), value, options);
+    default CompletionStage<Void> putProperty(final CharSequence path, final double value, final Option<?>... options) {
+        return putProperty(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -105,11 +107,11 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
     default CompletionStage<Void> putProperty(final CharSequence path, final int value, final Option<?>... options) {
-        argumentNotNull(path);
-        return putProperty(JsonFactory.newPointer(path), value, options);
+        return putProperty(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -121,7 +123,8 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
     CompletionStage<Void> putProperty(JsonPointer path, int value, Option<?>... options);
 
@@ -135,11 +138,11 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
     default CompletionStage<Void> putProperty(final CharSequence path, final long value, final Option<?>... options) {
-        argumentNotNull(path);
-        return putProperty(JsonFactory.newPointer(path), value, options);
+        return putProperty(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -151,7 +154,8 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
     CompletionStage<Void> putProperty(JsonPointer path, long value, Option<?>... options);
 
@@ -165,12 +169,11 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
-    default CompletionStage<Void> putProperty(final CharSequence path, final String value,
-            final Option<?>... options) {
-        argumentNotNull(path);
-        return putProperty(JsonFactory.newPointer(path), value, options);
+    default CompletionStage<Void> putProperty(final CharSequence path, final String value, final Option<?>... options) {
+        return putProperty(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -182,7 +185,8 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
     CompletionStage<Void> putProperty(JsonPointer path, String value, Option<?>... options);
 
@@ -196,12 +200,14 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
-    default CompletionStage<Void> putProperty(final CharSequence path, final JsonValue value,
+    default CompletionStage<Void> putProperty(final CharSequence path,
+            final JsonValue value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return putProperty(JsonFactory.newPointer(path), value, options);
+
+        return putProperty(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -213,7 +219,8 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for putting a feature property.
      */
     CompletionStage<Void> putProperty(JsonPointer path, JsonValue value, Option<?>... options);
 
@@ -227,13 +234,15 @@ public interface FeaturePropertiesManagement {
      * org.eclipse.ditto.client.options.Options}.
      * @return a completable future providing the result of this operation or a specific {@link
      * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for merging a feature property.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeProperty(final CharSequence path, final boolean value,
+    default CompletionStage<Void> mergeProperty(final CharSequence path,
+            final boolean value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeProperty(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+
+        return mergeProperty(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -246,13 +255,15 @@ public interface FeaturePropertiesManagement {
      * org.eclipse.ditto.client.options.Options}.
      * @return a completable future providing the result of this operation or a specific {@link
      * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for merging a feature property.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeProperty(final CharSequence path, final double value,
+    default CompletionStage<Void> mergeProperty(final CharSequence path,
+            final double value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeProperty(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+
+        return mergeProperty(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -266,13 +277,12 @@ public interface FeaturePropertiesManagement {
      * org.eclipse.ditto.client.options.Options}.
      * @return a completable future providing the result of this operation or a specific {@link
      * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for merging a feature property.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeProperty(final CharSequence path, final int value,
-            final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeProperty(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+    default CompletionStage<Void> mergeProperty(final CharSequence path, final int value, final Option<?>... options) {
+        return mergeProperty(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -286,13 +296,12 @@ public interface FeaturePropertiesManagement {
      * org.eclipse.ditto.client.options.Options}.
      * @return a completable future providing the result of this operation or a specific {@link
      * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for merging a feature property.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeProperty(final CharSequence path, final long value,
-            final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeProperty(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+    default CompletionStage<Void> mergeProperty(final CharSequence path, final long value, final Option<?>... options) {
+        return mergeProperty(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -306,13 +315,15 @@ public interface FeaturePropertiesManagement {
      * org.eclipse.ditto.client.options.Options}.
      * @return a completable future providing the result of this operation or a specific {@link
      * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for merging a feature property.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeProperty(final CharSequence path, final String value,
+    default CompletionStage<Void> mergeProperty(final CharSequence path,
+            final String value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeProperty(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+
+        return mergeProperty(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -325,13 +336,15 @@ public interface FeaturePropertiesManagement {
      * org.eclipse.ditto.client.options.Options}.
      * @return a completable future providing the result of this operation or a specific {@link
      * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for merging a feature property.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeProperty(final CharSequence path, final JsonValue value,
+    default CompletionStage<Void> mergeProperty(final CharSequence path,
+            final JsonValue value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeProperty(JsonFactory.newPointer(path), value, options);
+
+        return mergeProperty(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -343,7 +356,8 @@ public interface FeaturePropertiesManagement {
      * org.eclipse.ditto.client.options.Options}.
      * @return a completable future providing the result of this operation or a specific {@link
      * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains
+     * an option that is not allowed for merging a feature property.
      * @since 2.0.0
      */
     CompletionStage<Void> mergeProperty(JsonPointer path, JsonValue value, Option<?>... options);
@@ -356,6 +370,8 @@ public interface FeaturePropertiesManagement {
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @throws IllegalArgumentException if {@code options} contains an option
+     * that is not allowed for setting feature properties.
      */
     CompletionStage<Void> setProperties(JsonObject value, Option<?>... options);
 
@@ -363,10 +379,12 @@ public interface FeaturePropertiesManagement {
      * Merge the given properties of the Feature.
      *
      * @param value the properties to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return a completable future providing the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return a completable future providing the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @throws IllegalArgumentException if {@code options} contains an option
+     * that is not allowed for merging feature properties.
      * @since 2.0.0
      */
     CompletionStage<Void> mergeProperties(JsonObject value, Option<?>... options);
@@ -378,12 +396,13 @@ public interface FeaturePropertiesManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty
+     * or if {@code options} contains an option that is not allowed for
+     * deleting a feature property.
      */
     default CompletionStage<Void> deleteProperty(final CharSequence path, final Option<?>... options) {
-        argumentNotNull(path);
-        return deleteProperty(JsonFactory.newPointer(path), options);
+        return deleteProperty(JsonFactory.newPointer(argumentNotNull(path)), options);
     }
 
     /**
@@ -393,8 +412,10 @@ public interface FeaturePropertiesManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty
+     * or if {@code options} contains an option that is not allowed for
+     * deleting a feature property.
      */
     CompletionStage<Void> deleteProperty(JsonPointer path, Option<?>... options);
 
@@ -404,7 +425,9 @@ public interface FeaturePropertiesManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code options} contains an option
+     * that is not allowed for deleting feature properties.
      */
     CompletionStage<Void> deleteProperties(Option<?>... options);
 

--- a/java/src/main/java/org/eclipse/ditto/client/management/ThingAttributeManagement.java
+++ b/java/src/main/java/org/eclipse/ditto/client/management/ThingAttributeManagement.java
@@ -23,8 +23,8 @@ import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 
 /**
- * {@code ThingAttributeManagement} provides all functionality required for managing {@link
- * org.eclipse.ditto.things.model.Thing} attributes.
+ * {@code ThingAttributeManagement} provides all functionality required for managing
+ * {@link org.eclipse.ditto.things.model.Thing} attributes.
  * <p>
  * Note: All methods returning a {@link CompletionStage} are executed non-blocking and asynchronously.
  * Therefore, these methods return a {@code CompletionStage} object that will complete either successfully
@@ -44,13 +44,15 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
-    default CompletionStage<Void> putAttribute(final CharSequence path, final boolean value,
+    default CompletionStage<Void> putAttribute(final CharSequence path,
+            final boolean value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return putAttribute(JsonFactory.newPointer(path), value, options);
+
+        return putAttribute(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -61,8 +63,9 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
     CompletionStage<Void> putAttribute(JsonPointer path, boolean value, Option<?>... options);
 
@@ -75,13 +78,15 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
-    default CompletionStage<Void> putAttribute(final CharSequence path, final double value,
+    default CompletionStage<Void> putAttribute(final CharSequence path,
+            final double value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return putAttribute(JsonFactory.newPointer(path), value, options);
+
+        return putAttribute(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -92,8 +97,9 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
     CompletionStage<Void> putAttribute(JsonPointer path, double value, Option<?>... options);
 
@@ -106,12 +112,12 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
     default CompletionStage<Void> putAttribute(final CharSequence path, final int value, final Option<?>... options) {
-        argumentNotNull(path);
-        return putAttribute(JsonFactory.newPointer(path), value, options);
+        return putAttribute(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -122,8 +128,9 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
     CompletionStage<Void> putAttribute(JsonPointer path, int value, Option<?>... options);
 
@@ -136,13 +143,12 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
-    default CompletionStage<Void> putAttribute(final CharSequence path, final long value,
-            final Option<?>... options) {
-        argumentNotNull(path);
-        return putAttribute(JsonFactory.newPointer(path), value, options);
+    default CompletionStage<Void> putAttribute(final CharSequence path, final long value, final Option<?>... options) {
+        return putAttribute(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -153,8 +159,9 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
     CompletionStage<Void> putAttribute(JsonPointer path, long value, Option<?>... options);
 
@@ -167,13 +174,15 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
-    default CompletionStage<Void> putAttribute(final CharSequence path, final String value,
+    default CompletionStage<Void> putAttribute(final CharSequence path,
+            final String value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return putAttribute(JsonFactory.newPointer(path), value, options);
+
+        return putAttribute(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -184,8 +193,9 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
     CompletionStage<Void> putAttribute(JsonPointer path, String value, Option<?>... options);
 
@@ -198,13 +208,15 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for putting an attribute.
      */
-    default CompletionStage<Void> putAttribute(final CharSequence path, final JsonValue value,
+    default CompletionStage<Void> putAttribute(final CharSequence path,
+            final JsonValue value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return putAttribute(JsonFactory.newPointer(path), value, options);
+
+        return putAttribute(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -215,8 +227,9 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if any argument is {@code null} or if {@code path} is empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if any argument is {@code null} or if {@code path} is empty or
+     * if {@code options} contains an option that is not allowed for putting an attribute.
      */
     CompletionStage<Void> putAttribute(JsonPointer path, JsonValue value, Option<?>... options);
 
@@ -226,17 +239,19 @@ public interface ThingAttributeManagement {
      * @param path the path to the attribute value to be merged - may contain {@code "/"} for addressing nested paths
      * in a hierarchy.
      * @param value the attribute value to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return a completable future providing the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return a completable future providing the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for merging an attribute.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeAttribute(final CharSequence path, final boolean value,
+    default CompletionStage<Void> mergeAttribute(final CharSequence path,
+            final boolean value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeAttribute(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+
+        return mergeAttribute(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -245,17 +260,19 @@ public interface ThingAttributeManagement {
      * @param path the path to the attribute value to be merged - may contain {@code "/"} for addressing nested paths
      * in a hierarchy.
      * @param value the attribute value to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return a completable future providing the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return a completable future providing the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for merging an attribute.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeAttribute(final CharSequence path, final double value,
+    default CompletionStage<Void> mergeAttribute(final CharSequence path,
+            final double value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeAttribute(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+
+        return mergeAttribute(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -264,17 +281,16 @@ public interface ThingAttributeManagement {
      * @param path the path to the attribute value to be merged - may contain {@code "/"} for addressing nested paths
      * in a hierarchy.
      * @param value the attribute value to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return a completable future providing the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return a completable future providing the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for merging an attribute.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeAttribute(final CharSequence path, final int value,
-            final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeAttribute(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+    default CompletionStage<Void> mergeAttribute(final CharSequence path, final int value, final Option<?>... options) {
+        return mergeAttribute(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -283,17 +299,19 @@ public interface ThingAttributeManagement {
      * @param path the path to the attribute value to be merged - may contain {@code "/"} for addressing nested paths
      * in a hierarchy.
      * @param value the attribute value to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return a completable future providing the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return a completable future providing the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for merging an attribute.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeAttribute(final CharSequence path, final long value,
+    default CompletionStage<Void> mergeAttribute(final CharSequence path,
+            final long value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeAttribute(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+
+        return mergeAttribute(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -302,17 +320,19 @@ public interface ThingAttributeManagement {
      * @param path the path to the attribute value to be merged - may contain {@code "/"} for addressing nested paths
      * in a hierarchy.
      * @param value the attribute value to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return a completable future providing the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return a completable future providing the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for merging an attribute.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeAttribute(final CharSequence path, final String value,
+    default CompletionStage<Void> mergeAttribute(final CharSequence path,
+            final String value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeAttribute(JsonFactory.newPointer(path), JsonFactory.newValue(value), options);
+
+        return mergeAttribute(JsonFactory.newPointer(argumentNotNull(path)), JsonFactory.newValue(value), options);
     }
 
     /**
@@ -321,17 +341,19 @@ public interface ThingAttributeManagement {
      * @param path the path to the attribute value to be merged - may contain {@code "/"} for addressing nested paths
      * in a hierarchy.
      * @param value the attribute value to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return a completable future providing the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return a completable future providing the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for merging an attribute.
      * @since 2.0.0
      */
-    default CompletionStage<Void> mergeAttribute(final CharSequence path, final JsonValue value,
+    default CompletionStage<Void> mergeAttribute(final CharSequence path,
+            final JsonValue value,
             final Option<?>... options) {
-        argumentNotNull(path);
-        return mergeAttribute(JsonFactory.newPointer(path), value, options);
+
+        return mergeAttribute(JsonFactory.newPointer(argumentNotNull(path)), value, options);
     }
 
     /**
@@ -339,11 +361,12 @@ public interface ThingAttributeManagement {
      *
      * @param path the hierarchical path to the attribute value to be merged.
      * @param value the attribute value to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return a completable future providing the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if any argument is {@code null} or if {@code path} is empty.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return a completable future providing the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if any argument is {@code null} or if {@code path} is empty or if
+     * {@code options} contains an option that is not allowed for merging an attribute.
      * @since 2.0.0
      */
     CompletionStage<Void> mergeAttribute(JsonPointer path, JsonValue value, Option<?>... options);
@@ -355,8 +378,9 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code value} is {@code null}
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code value} is {@code null} or if {@code options} contains an
+     * option that is not allowed for setting attributes.
      */
     CompletionStage<Void> setAttributes(JsonObject value, Option<?>... options);
 
@@ -364,11 +388,12 @@ public interface ThingAttributeManagement {
      * Merge the given attributes to this Thing.
      *
      * @param value the attributes to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return a completable future providing the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code value} is {@code null}
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return a completable future providing the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code value} is {@code null} or if {@code options} contains an
+     * option that is not allowed for merging attributes.
      * @since 2.0.0
      */
     CompletionStage<Void> mergeAttributes(JsonObject value, Option<?>... options);
@@ -377,28 +402,29 @@ public interface ThingAttributeManagement {
      * Deletes the attribute specified by the given path.
      *
      * @param path the path to the attribute to be created/modified within the attributes using {@code "/"} as
-     * separator, e. g. {@code "address/city"}.
+     * separator, e.g. {@code "address/city"}.
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for deleting an attribute.
      */
     default CompletionStage<Void> deleteAttribute(final CharSequence path, final Option<?>... options) {
-        argumentNotNull(path);
-        return deleteAttribute(JsonFactory.newPointer(path), options);
+        return deleteAttribute(JsonFactory.newPointer(argumentNotNull(path)), options);
     }
 
     /**
      * Deletes the attribute specified by the given path.
      *
      * @param path the path to the attribute to be created/modified within the attributes using {@code "/"} as
-     * separator, e. g. {@code "address/city"}.
+     * separator, e.g. {@code "address/city"}.
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code path} is {@code null} or empty.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code path} is {@code null} or empty or if {@code options} contains an
+     * option that is not allowed for deleting an attribute.
      */
     CompletionStage<Void> deleteAttribute(JsonPointer path, Option<?>... options);
 
@@ -408,7 +434,9 @@ public interface ThingAttributeManagement {
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return a CompletionStage providing the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for
+     * deleting attributes.
      */
     CompletionStage<Void> deleteAttributes(Option<?>... options);
 

--- a/java/src/main/java/org/eclipse/ditto/client/management/ThingHandle.java
+++ b/java/src/main/java/org/eclipse/ditto/client/management/ThingHandle.java
@@ -55,9 +55,9 @@ import org.eclipse.ditto.things.model.WithThingId;
  * @param <F> the type of {@link FeatureHandle} for handling {@code Feature}s
  * @since 1.0.0
  */
-public interface ThingHandle<F extends FeatureHandle> extends WithThingId, ThingAttributeManagement,
-        ThingAttributeChangeRegistration,
-        FeatureChangeRegistration, ThingChangeRegistration {
+public interface ThingHandle<F extends FeatureHandle>
+        extends WithThingId, ThingAttributeManagement, ThingAttributeChangeRegistration, FeatureChangeRegistration,
+        ThingChangeRegistration {
 
     /**
      * Creates a new instance of {@link FeatureHandle} which aggregates all operations of an already existing
@@ -75,7 +75,9 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * @param options options to be applied configuring behaviour of this method, see
      * {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage providing for handling the deletion a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for deleting
+     * a thing.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      */
     CompletionStage<Void> delete(Option<?>... options);
 
@@ -95,6 +97,8 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * @return CompletionStage providing the requested {@link Thing} or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws NullPointerException if {@code options} is {@code null}.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for retrieving
+     * a thing.
      * @since 2.1.0
      */
     CompletionStage<Thing> retrieve(Option<?>... options);
@@ -117,6 +121,8 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * @return CompletionStage providing the requested {@link Thing} or a specific
      * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for retrieving
+     * a thing.
      * @since 2.1.0
      */
     CompletionStage<Thing> retrieve(JsonFieldSelector fieldSelector, Option<?>... options);
@@ -128,8 +134,9 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage for handling the result of the operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code policyId} is {@code null}.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code policyId} is {@code null} or if {@code options} contains an option
+     * that is not allowed for setting a policy ID to a thing.
      * @since 1.1.0
      */
     CompletionStage<Void> setPolicyId(PolicyId policyId, Option<?>... options);
@@ -138,11 +145,12 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * Merge the given {@code policyId} to this Thing.
      *
      * @param policyId the PolicyId of the Policy to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage for handling the result of the operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code policyId} is {@code null}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage for handling the result of the operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code policyId} is {@code null} or if {@code options} contains an option
+     * that is not allowed for merging a policy ID to a thing.
      * @since 2.0.0
      */
     CompletionStage<Void> mergePolicyId(PolicyId policyId, Option<?>... options);
@@ -154,8 +162,9 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage for handling the result of the operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code features} is {@code null}.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code features} is {@code null} or if {@code options} contains an option
+     * that is not allowed for setting features to a thing.
      */
     CompletionStage<Void> setFeatures(Features features, Option<?>... options);
 
@@ -167,7 +176,8 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage for handling the result of the operation or a specific {@link
      * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code features} is {@code null}.
+     * @throws IllegalArgumentException if {@code features} is {@code null} or if {@code options} contains an option
+     * that is not allowed for merging features to a thing.
      * @since 2.0.0
      */
     CompletionStage<Void> mergeFeatures(Features features, Option<?>... options);
@@ -179,8 +189,9 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage for handling the result of this operation or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code feature} is {@code null}.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code feature} is {@code null} or if {@code options} contains an option
+     * that is not allowed for putting a feature to a thing.
      */
     CompletionStage<Void> putFeature(Feature feature, Option<?>... options);
 
@@ -188,11 +199,12 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * Merges the given Feature of this Thing or creates a new one if it does not yet exist.
      *
      * @param feature Feature to be merged.
-     * @param options options to be applied configuring behaviour of this method, see {@link
-     * org.eclipse.ditto.client.options.Options}.
-     * @return CompletionStage for handling the result of this operation or a specific {@link
-     * org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
-     * @throws IllegalArgumentException if {@code feature} is {@code null}.
+     * @param options options to be applied configuring behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage for handling the result of this operation or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code feature} is {@code null} or if {@code options} contains an option
+     * that is not allowed for merging a feature to a thing.
      * @since 2.0.0
      */
     CompletionStage<Void> mergeFeature(Feature feature, Option<?>... options);
@@ -204,9 +216,9 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage for handling the deletion or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException}
-     * if the operation failed
-     * @throws IllegalArgumentException if {@code featureId} is {@code null}.
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException if {@code featureId} is {@code null} or if {@code options} contains an option
+     * that is not allowed for deleting a feature from a thing.
      */
     CompletionStage<Void> deleteFeature(String featureId, Option<?>... options);
 
@@ -216,8 +228,9 @@ public interface ThingHandle<F extends FeatureHandle> extends WithThingId, Thing
      * @param options options to be applied configuring behaviour of this method,
      * see {@link org.eclipse.ditto.client.options.Options}.
      * @return CompletionStage for handling the deletion or a specific
-     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException}
-     * if the operation failed
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws IllegalArgumentException or if {@code options} contains an option that is not allowed for deleting
+     * features from a thing.
      */
     CompletionStage<Void> deleteFeatures(Option<?>... options);
 

--- a/java/src/main/java/org/eclipse/ditto/client/options/OptionName.java
+++ b/java/src/main/java/org/eclipse/ditto/client/options/OptionName.java
@@ -46,9 +46,21 @@ public interface OptionName extends Predicate<Object> {
 
         /**
          * Name of the option for defining the DittoHeaders to send along with a command/message to the Ditto backend.
+         *
          * @since 1.1.0
          */
-        DITTO_HEADERS
+        DITTO_HEADERS,
+
+        /**
+         * Name of the option for defining a "live channel condition", which, when evaluating to {@code true}, shall
+         * switch the channel to use to {@code "live"}.
+         * The condition is defined via an RQL expression, which is evaluated in the Things service persistence.
+         * If the condition evaluates to {@code true}, then the live channel is used instead of the regular
+         * twin channel.
+         *
+         * @since 2.3.0
+         */
+        LIVE_CHANNEL_CONDITION,
 
     }
 

--- a/java/src/main/java/org/eclipse/ditto/client/options/Options.java
+++ b/java/src/main/java/org/eclipse/ditto/client/options/Options.java
@@ -69,6 +69,28 @@ public final class Options {
     }
 
     /**
+     * Creates an option for specifying the RQL expression that acts as live channel condition.
+     * <p>
+     * The returned option has the name {@link OptionName.Global#LIVE_CHANNEL_CONDITION} and the given argument value.
+     * </p>
+     *
+     * @param liveChannelConditionExpression the RQL expression that acts as live channel condition.
+     * @return the new {@code Option}.
+     * @throws NullPointerException if {@code liveChannelConditionExpression} is {@code null}.
+     * @throws IllegalArgumentException if {@code liveChannelConditionExpression} is blank.
+     * @since 2.3.0
+     */
+    public static Option<String> liveChannelCondition(final CharSequence liveChannelConditionExpression) {
+        ConditionChecker.checkNotNull(liveChannelConditionExpression, "liveChannelConditionExpression");
+        ConditionChecker.checkArgument(liveChannelConditionExpression,
+                argument -> 0 < argument.chars().filter(ch -> !Character.isWhitespace(ch)).count(),
+                () -> "The liveChannelConditionExpression must not be blank.");
+
+        return DefaultOption.newInstance(OptionName.Global.LIVE_CHANNEL_CONDITION,
+                liveChannelConditionExpression.toString());
+    }
+
+    /**
      * The {@code Modify} class provides static factory methods for creating Options which are related to modifying
      * operations.
      *
@@ -122,7 +144,7 @@ public final class Options {
         }
 
         /**
-         * Creates an option for specifying whether the created policy should copied from an already existing policy
+         * Creates an option for specifying whether the created policy should be copied from an already existing policy.
          * <p>
          * The returned option has the name {@link OptionName.Modify#COPY_POLICY} and the given {@code boolean} value.
          * </p>
@@ -141,7 +163,8 @@ public final class Options {
         /**
          * Creates an option for specifying whether the created policy should be copied from an already existing thing
          * <p>
-         * The returned option has the name {@link OptionName.Modify#COPY_POLICY_FROM_THING} and the given {@code boolean} value.
+         * The returned option has the name {@link OptionName.Modify#COPY_POLICY_FROM_THING} and the given
+         * {@code boolean} value.
          * </p>
          * <p>
          * If this Option is not specified, it does not matter whether the object exists.

--- a/java/src/main/java/org/eclipse/ditto/client/options/internal/LiveChannelConditionOptionVisitor.java
+++ b/java/src/main/java/org/eclipse/ditto/client/options/internal/LiveChannelConditionOptionVisitor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.client.options.internal;
+
+import org.eclipse.ditto.client.options.Option;
+import org.eclipse.ditto.client.options.OptionName;
+
+/**
+ * This visitor fetches and provides the value as {@code String} for
+ * the {@link Option} with name {@link OptionName.Global#LIVE_CHANNEL_CONDITION}
+ * from the user provided options.
+ *
+ * @since 2.3.0
+ */
+final class LiveChannelConditionOptionVisitor extends AbstractOptionVisitor<String> {
+
+    /**
+     * Constructs a new {@code LiveChannelConditionOptionVisitor} object.
+     */
+    LiveChannelConditionOptionVisitor() {
+        super(OptionName.Global.LIVE_CHANNEL_CONDITION);
+    }
+
+    @Override
+    protected String getValueFromOption(final Option<?> option) {
+        return option.getValueAs(String.class);
+    }
+
+}

--- a/java/src/main/java/org/eclipse/ditto/client/options/internal/OptionsEvaluator.java
+++ b/java/src/main/java/org/eclipse/ditto/client/options/internal/OptionsEvaluator.java
@@ -120,6 +120,18 @@ public final class OptionsEvaluator {
             return getValue(new ConditionOptionVisitor());
         }
 
+        /**
+         * Returns the live channel condition RQL expression as provided by
+         * the user.
+         *
+         * @return an Optional containing the live channel condition
+         * RQL expression if provided by the user, an empty Optional else.
+         * @since 2.3.0
+         */
+        public Optional<String> getLiveChannelCondition() {
+            return getValue(new LiveChannelConditionOptionVisitor());
+        }
+
     }
 
     /**

--- a/java/src/test/java/org/eclipse/ditto/client/internal/OutgoingMessageFactoryTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/internal/OutgoingMessageFactoryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.client.internal;
+
+import static org.eclipse.ditto.client.TestConstants.Feature.FLUX_CAPACITOR_ID;
+import static org.eclipse.ditto.client.TestConstants.Thing.THING_ID;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.client.options.OptionName;
+import org.eclipse.ditto.client.options.Options;
+import org.eclipse.ditto.things.model.signals.commands.query.RetrieveFeature;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link OutgoingMessageFactory}.
+ */
+public final class OutgoingMessageFactoryTest {
+
+    private static final JsonSchemaVersion JSON_SCHEMA_VERSION = JsonSchemaVersion.V_2;
+    private static final String CONDITION_EXPRESSION = "ne(attributes/test)";
+    private static final String LIVE_CHANNEL_CONDITION_EXPRESSION = "eq(attributes/value,\"livePolling\")";
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    private OutgoingMessageFactory underTest;
+
+    @Before
+    public void before() {
+        underTest = OutgoingMessageFactory.newInstance(JSON_SCHEMA_VERSION);
+    }
+
+    @Test
+    public void retrieveFeatureWithOnlyAllowedOptionsReturnsExpected() {
+        final RetrieveFeature retrieveFeature = underTest.retrieveFeature(THING_ID,
+                FLUX_CAPACITOR_ID,
+                Options.condition(CONDITION_EXPRESSION),
+                Options.liveChannelCondition(LIVE_CHANNEL_CONDITION_EXPRESSION));
+
+        softly.assertThat((CharSequence) retrieveFeature.getEntityId())
+                .as("entity ID")
+                .isEqualTo(THING_ID);
+        softly.assertThat(retrieveFeature.getFeatureId()).as("feature ID").isEqualTo(FLUX_CAPACITOR_ID);
+        softly.assertThat(retrieveFeature.getDittoHeaders())
+                .as("Ditto headers")
+                .satisfies(dittoHeaders -> {
+                    softly.assertThat(dittoHeaders)
+                            .as("condition expression")
+                            .containsEntry(DittoHeaderDefinition.CONDITION.getKey(), CONDITION_EXPRESSION);
+                    softly.assertThat(dittoHeaders)
+                            .as("live channel condition expression")
+                            .containsEntry(DittoHeaderDefinition.LIVE_CHANNEL_CONDITION.getKey(),
+                                    LIVE_CHANNEL_CONDITION_EXPRESSION);
+                });
+    }
+
+    @Test
+    public void deleteThingWithLiveChannelConditionExpressionThrowsException() {
+        Assertions.assertThatIllegalArgumentException()
+                .isThrownBy(() -> underTest.deleteThing(THING_ID, Options.liveChannelCondition(LIVE_CHANNEL_CONDITION_EXPRESSION)))
+                .withMessage("Option '%s' is not allowed. This operation only allows [%s, %s, %s].",
+                        OptionName.Global.LIVE_CHANNEL_CONDITION,
+                        OptionName.Global.CONDITION,
+                        OptionName.Global.DITTO_HEADERS,
+                        OptionName.Modify.RESPONSE_REQUIRED)
+                .withNoCause();
+    }
+
+}

--- a/java/src/test/java/org/eclipse/ditto/client/options/OptionsTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/options/OptionsTest.java
@@ -15,6 +15,9 @@ package org.eclipse.ditto.client.options;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -22,9 +25,46 @@ import org.junit.Test;
  */
 public final class OptionsTest {
 
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
     @Test
     public void assertImmutability() {
         assertInstancesOf(Options.class, areImmutable());
+    }
+
+    @Test
+    public void lifeChannelConditionWithNullExpressionThrowsException() {
+        Assertions.assertThatNullPointerException()
+                .isThrownBy(() -> Options.liveChannelCondition(null))
+                .withMessage("The liveChannelConditionExpression must not be null!")
+                .withNoCause();
+    }
+
+    @Test
+    public void lifeChannelConditionWithEmptyExpressionThrowsException() {
+        Assertions.assertThatIllegalArgumentException()
+                .isThrownBy(() -> Options.liveChannelCondition(""))
+                .withMessage("The liveChannelConditionExpression must not be blank.")
+                .withNoCause();
+    }
+
+    @Test
+    public void lifeChannelConditionWithBlankExpressionThrowsException() {
+        Assertions.assertThatIllegalArgumentException()
+                .isThrownBy(() -> Options.liveChannelCondition("     "))
+                .withMessage("The liveChannelConditionExpression must not be blank.")
+                .withNoCause();
+    }
+
+    @Test
+    public void lifeChannelConditionWithValidExpressionReturnsExpected() {
+        final String liveChannelConditionExpression = "eq(attributes/value,\"livePolling\")";
+
+        final Option<String> option = Options.liveChannelCondition(liveChannelConditionExpression);
+
+        softly.assertThat(option.getName()).as("option name").isEqualTo(OptionName.Global.LIVE_CHANNEL_CONDITION);
+        softly.assertThat(option.getValue()).as("option value").isEqualTo(liveChannelConditionExpression);
     }
 
 }

--- a/java/src/test/java/org/eclipse/ditto/client/options/internal/LiveChannelConditionOptionVisitorTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/options/internal/LiveChannelConditionOptionVisitorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.client.options.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.client.options.Option;
+import org.eclipse.ditto.client.options.Options;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+/**
+ * Unit test for {@link LiveChannelConditionOptionVisitor}.
+ */
+public final class LiveChannelConditionOptionVisitorTest {
+
+    private static final String LIVE_CHANNEL_CONDITION_EXPRESSION = "eq(attributes/value,\"livePolling\")";
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    private DittoHeaders dittoHeaders;
+
+    private LiveChannelConditionOptionVisitor underTest;
+
+    @Before
+    public void before() {
+        dittoHeaders = DittoHeaders.newBuilder().correlationId(testName.getMethodName()).build();
+        underTest = new LiveChannelConditionOptionVisitor();
+    }
+
+    @Test
+    public void visitWithNullOptionThrowsException() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> underTest.visit(null))
+                .withMessage("The option to be visited must not be null!")
+                .withNoCause();
+    }
+
+    @Test
+    public void getValueFromOptionWithUnexpectedValueTypeThrowsException() {
+        final Option<DittoHeaders> headersOption = Options.headers(dittoHeaders);
+
+        assertThatExceptionOfType(ClassCastException.class)
+                .isThrownBy(() -> underTest.getValueFromOption(headersOption))
+                .withMessage("Cannot cast %s to %s", dittoHeaders.getClass().getName(), String.class.getName())
+                .withNoCause();
+    }
+
+    @Test
+    public void visitOptionWithUnexpectedNameReturnsFalse() {
+        final Option<DittoHeaders> headersOption = Options.headers(dittoHeaders);
+
+        assertThat(underTest.visit(headersOption)).isFalse();
+    }
+
+    @Test
+    public void visitAppropriateOptionReturnsTrue() {
+        final Option<String> liveChannelConditionOption =
+                Options.liveChannelCondition(LIVE_CHANNEL_CONDITION_EXPRESSION);
+
+        assertThat(underTest.visit(liveChannelConditionOption)).isTrue();
+    }
+
+    @Test
+    public void visitAppropriateOptionAndGetValueReturnsExpectedValue() {
+        final Option<String> liveChannelConditionOption =
+                Options.liveChannelCondition(LIVE_CHANNEL_CONDITION_EXPRESSION);
+
+        underTest.visit(liveChannelConditionOption);
+
+        assertThat(underTest.getValue()).contains(LIVE_CHANNEL_CONDITION_EXPRESSION);
+    }
+
+}


### PR DESCRIPTION
See [Ditto issue #1228](https://github.com/eclipse/ditto/issues/1228) to learn about the smart channel strategy feature.
Also added some missing Javadoc comments for possibly thrown exceptions.

Signed-off-by: Juergen Fickel <juergen.fickel@bosch.io>