### PR TITLE
Add option for field selectors and options to RetrievePolicy API

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/internal/OutgoingMessageFactory.java
+++ b/java/src/main/java/org/eclipse/ditto/client/internal/OutgoingMessageFactory.java
@@ -222,7 +222,7 @@ public final class OutgoingMessageFactory {
             final Option<?>... options) {
 
         return RetrieveThing.getBuilder(thingId,
-                        buildDittoHeaders(EnumSet.of(CONDITION, LIVE_CHANNEL_CONDITION), options))
+                buildDittoHeaders(EnumSet.of(CONDITION, LIVE_CHANNEL_CONDITION), options))
                 .withSelectedFields(JsonFactory.newFieldSelector(fields))
                 .build();
     }
@@ -298,16 +298,17 @@ public final class OutgoingMessageFactory {
         return ModifyPolicy.of(policyId, policy, headers);
     }
 
-    /**
-     * Builds a command to retrieve the policy with ID {@code policyId}.
-     *
-     * @param policyId the policy to retrieve.
-     * @return the {@link RetrievePolicy} command.
-     * @throws NullPointerException if the policyId is {@code null}.
-     * @since 1.1.0
-     */
-    public RetrievePolicy retrievePolicy(final PolicyId policyId) {
-        return RetrievePolicy.of(policyId, buildDittoHeaders(Collections.emptySet()));
+    public RetrievePolicy retrievePolicy(final PolicyId policyId, final Option<?>... options) {
+        return RetrievePolicy.of(policyId, buildDittoHeaders(Collections.emptySet(), options));
+    }
+
+    public RetrievePolicy retrievePolicy(final PolicyId policyId,
+            final Iterable<JsonPointer> fields,
+            final Option<?>... options) {
+
+        return RetrievePolicy.of(policyId,
+                buildDittoHeaders(Collections.emptySet(), options),
+                JsonFactory.newFieldSelector(fields));
     }
 
     /**

--- a/java/src/main/java/org/eclipse/ditto/client/policies/Policies.java
+++ b/java/src/main/java/org/eclipse/ditto/client/policies/Policies.java
@@ -16,9 +16,11 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 import org.eclipse.ditto.client.options.Option;
+import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.things.model.Thing;
 
 /**
  * A {@code Policy} provides the basic functionality, which can be used to manage (i.e. create and delete)
@@ -153,7 +155,7 @@ public interface Policies {
     CompletionStage<Void> delete(PolicyId policyId, Option<?>... options);
 
     /**
-     * Gets the {@link org.eclipse.ditto.policies.model.Policy} specified by the given identifier.
+     * Gets the {@code Policy} specified by the given identifier.
      *
      * @param policyId the identifier of the Policy to be retrieved.
      * @return CompletionStage providing the requested Policy or a specific
@@ -161,4 +163,46 @@ public interface Policies {
      * @throws IllegalArgumentException if {@code policyId} is {@code null}.
      */
     CompletionStage<Policy> retrieve(PolicyId policyId);
+
+
+    /**
+     * Gets the {@code Policy} specified by the given identifier with the given options.
+     *
+     * @param options options that determine the behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the requested {@link Thing} or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws NullPointerException if {@code options} is {@code null}.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for retrieving
+     * a thing.
+     * @since 2.4.0
+     */
+    CompletionStage<Policy> retrieve(PolicyId policyId, Option<?>... options);
+
+    /**
+     * Retrieve the {@code Policy} specified by the given identifier, containing the fields specified by
+     * the given {@code fieldSelector}.
+     *
+     * @param fieldSelector a field selector object allowing to select a subset of fields on the Policy to be retrieved.
+     * @return CompletionStage providing the requested {@link Policy} or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed
+     * @since 2.4.0
+     */
+    CompletionStage<Policy> retrieve(PolicyId policyId, JsonFieldSelector fieldSelector);
+
+    /**
+     * Gets the {@code Policy} specified by the given identifier with the given options, containing the fields
+     * specified by the given {@code fieldSelector}.
+     *
+     * @param fieldSelector a field selector object allowing to select a subset of fields on the Policy to be retrieved.
+     * @param options options that determine the behaviour of this method, see
+     * {@link org.eclipse.ditto.client.options.Options}.
+     * @return CompletionStage providing the requested {@link Policy} or a specific
+     * {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException} if the operation failed.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws IllegalArgumentException if {@code options} contains an option that is not allowed for retrieving
+     * a policy.
+     * @since 2.4.0
+     */
+    CompletionStage<Policy> retrieve(PolicyId policyId, JsonFieldSelector fieldSelector, Option<?>... options);
 }

--- a/java/src/main/java/org/eclipse/ditto/client/policies/internal/PoliciesImpl.java
+++ b/java/src/main/java/org/eclipse/ditto/client/policies/internal/PoliciesImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.client.internal.bus.PointerBus;
 import org.eclipse.ditto.client.messaging.MessagingProvider;
 import org.eclipse.ditto.client.options.Option;
 import org.eclipse.ditto.client.policies.Policies;
+import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
@@ -176,12 +177,32 @@ public final class PoliciesImpl extends AbstractHandle implements Policies {
     }
 
     @Override
-    public CompletionStage<Policy> retrieve(PolicyId policyId) {
+    public CompletionStage<Policy> retrieve(final PolicyId policyId) {
         final RetrievePolicy command = outgoingMessageFactory.retrievePolicy(policyId);
         return askPolicyCommand(command, RetrievePolicyResponse.class, response -> {
             final Policy policyFromResponse = response.getPolicy();
             return appendRevisionFromHeadersIfNeeded(policyFromResponse, response.getDittoHeaders());
         });
+    }
+
+    @Override
+    public CompletionStage<Policy> retrieve(final PolicyId policyId, final Option<?>... options) {
+        final RetrievePolicy command = outgoingMessageFactory.retrievePolicy(policyId, options);
+        return askPolicyCommand(command, RetrievePolicyResponse.class, RetrievePolicyResponse::getPolicy);
+    }
+
+    @Override
+    public CompletionStage<Policy> retrieve(final PolicyId policyId, final JsonFieldSelector fieldSelector) {
+        final RetrievePolicy command = outgoingMessageFactory.retrievePolicy(policyId, fieldSelector);
+        return askPolicyCommand(command, RetrievePolicyResponse.class, RetrievePolicyResponse::getPolicy);
+    }
+
+    @Override
+    public CompletionStage<Policy> retrieve(final PolicyId policyId, final JsonFieldSelector fieldSelector,
+            final Option<?>... options) {
+
+        final RetrievePolicy command = outgoingMessageFactory.retrievePolicy(policyId, fieldSelector, options);
+        return askPolicyCommand(command, RetrievePolicyResponse.class, RetrievePolicyResponse::getPolicy);
     }
 
     private static void assertThatPolicyHasId(final Policy policy) {

--- a/java/src/main/java/org/eclipse/ditto/client/policies/internal/PoliciesImpl.java
+++ b/java/src/main/java/org/eclipse/ditto/client/policies/internal/PoliciesImpl.java
@@ -20,10 +20,6 @@ import java.util.concurrent.CompletionStage;
 
 import javax.annotation.Nonnull;
 
-import org.eclipse.ditto.base.model.acks.AcknowledgementLabel;
-import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.headers.entitytag.EntityTag;
 import org.eclipse.ditto.client.internal.AbstractHandle;
 import org.eclipse.ditto.client.internal.OutgoingMessageFactory;
 import org.eclipse.ditto.client.internal.bus.PointerBus;
@@ -33,10 +29,12 @@ import org.eclipse.ditto.client.policies.Policies;
 import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.base.model.acks.AcknowledgementLabel;
+import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
-import org.eclipse.ditto.policies.model.PolicyRevision;
+import org.eclipse.ditto.protocol.TopicPath;
 import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicy;
 import org.eclipse.ditto.policies.model.signals.commands.modify.CreatePolicyResponse;
 import org.eclipse.ditto.policies.model.signals.commands.modify.DeletePolicy;
@@ -45,7 +43,6 @@ import org.eclipse.ditto.policies.model.signals.commands.modify.ModifyPolicyResp
 import org.eclipse.ditto.policies.model.signals.commands.modify.PolicyModifyCommandResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicy;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyResponse;
-import org.eclipse.ditto.protocol.TopicPath;
 
 /**
  * Default implementation for {@link Policies}.
@@ -79,33 +76,6 @@ public final class PoliciesImpl extends AbstractHandle implements Policies {
         return new PoliciesImpl(messagingProvider, outgoingMessageFactory, bus);
     }
 
-    private static Optional<PolicyRevision> getRevisionFromDittoHeaders(final DittoHeaders dittoHeaders) {
-        return dittoHeaders
-                .getETag()
-                .map(EntityTag::getOpaqueTag)
-                .filter(tag -> tag.contains("rev:"))
-                .map(tag -> tag.replace("rev:", "").replaceAll("\"", ""))
-                .map(Long::parseLong)
-                .map(PolicyRevision::newInstance);
-    }
-
-    private static Policy setRevisionToPolicy(final PolicyRevision policyRevision, final Policy policy) {
-        return policy.toBuilder()
-                .setRevision(policyRevision)
-                .build();
-    }
-
-    private static Policy appendRevisionFromHeadersIfNeeded(final Policy policy, final DittoHeaders dittoHeaders) {
-        final Policy policyWithRevision;
-        final Optional<PolicyRevision> revisionFromPolicy = policy.getRevision();
-        policyWithRevision = revisionFromPolicy
-                .map(policyRevision -> setRevisionToPolicy(policyRevision, policy))
-                .orElseGet(() -> getRevisionFromDittoHeaders(dittoHeaders)
-                        .map(revisionFromHeaders -> setRevisionToPolicy(revisionFromHeaders, policy))
-                        .orElse(policy));
-        return policyWithRevision;
-    }
-
     @Override
     public CompletionStage<Policy> create(final Policy policy, final Option<?>... options) {
         argumentNotNull(policy);
@@ -113,10 +83,7 @@ public final class PoliciesImpl extends AbstractHandle implements Policies {
 
         final CreatePolicy command = outgoingMessageFactory.createPolicy(policy, options);
         return askPolicyCommand(command, CreatePolicyResponse.class,
-                response -> response.getPolicyCreated()
-                        .map(policyFromResponse -> appendRevisionFromHeadersIfNeeded(policyFromResponse,
-                                response.getDittoHeaders()))
-                        .orElse(null));
+                response -> response.getPolicyCreated().orElse(null));
     }
 
     @Override
@@ -138,8 +105,6 @@ public final class PoliciesImpl extends AbstractHandle implements Policies {
                 response -> response.getEntity(response.getImplementedSchemaVersion())
                         .map(JsonValue::asObject)
                         .map(PoliciesModelFactory::newPolicy)
-                        .map(policyFromResponse -> appendRevisionFromHeadersIfNeeded(policyFromResponse,
-                                response.getDittoHeaders()))
         );
     }
 
@@ -179,10 +144,7 @@ public final class PoliciesImpl extends AbstractHandle implements Policies {
     @Override
     public CompletionStage<Policy> retrieve(final PolicyId policyId) {
         final RetrievePolicy command = outgoingMessageFactory.retrievePolicy(policyId);
-        return askPolicyCommand(command, RetrievePolicyResponse.class, response -> {
-            final Policy policyFromResponse = response.getPolicy();
-            return appendRevisionFromHeadersIfNeeded(policyFromResponse, response.getDittoHeaders());
-        });
+        return askPolicyCommand(command, RetrievePolicyResponse.class, RetrievePolicyResponse::getPolicy);
     }
 
     @Override

--- a/java/src/test/java/org/eclipse/ditto/client/DittoClientThingTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/DittoClientThingTest.java
@@ -582,6 +582,15 @@ public final class DittoClientThingTest extends AbstractDittoClientThingsTest {
     }
 
     @Test
+    public void retrieveThingWithExtraFieldsOption() {
+        assertEventualCompletion(getManagement().forId(THING_ID)
+                .retrieve(Options.Consumption.extraFields(JsonFieldSelector.newInstance("_revision"))));
+        final RetrieveThing retrieveThing = expectMsgClass(RetrieveThing.class);
+        reply(RetrieveThingResponse.of(THING_ID, TestConstants.Thing.THING_V2.toJson(), retrieveThing.getDittoHeaders()));
+        assertThat(retrieveThing.getSelectedFields()).contains(JsonFieldSelector.newInstance("_revision"));
+    }
+
+    @Test
     public void retrieveThingWithFieldSelectorAndConditionOption() {
         final JsonFieldSelector jsonFieldSelector = JsonFieldSelector.newInstance("attributes/manufacturer");
 

--- a/java/src/test/java/org/eclipse/ditto/client/DittoClientThingTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/DittoClientThingTest.java
@@ -582,15 +582,6 @@ public final class DittoClientThingTest extends AbstractDittoClientThingsTest {
     }
 
     @Test
-    public void retrieveThingWithExtraFieldsOption() {
-        assertEventualCompletion(getManagement().forId(THING_ID)
-                .retrieve(Options.Consumption.extraFields(JsonFieldSelector.newInstance("_revision"))));
-        final RetrieveThing retrieveThing = expectMsgClass(RetrieveThing.class);
-        reply(RetrieveThingResponse.of(THING_ID, TestConstants.Thing.THING_V2.toJson(), retrieveThing.getDittoHeaders()));
-        assertThat(retrieveThing.getSelectedFields()).contains(JsonFieldSelector.newInstance("_revision"));
-    }
-
-    @Test
     public void retrieveThingWithFieldSelectorAndConditionOption() {
         final JsonFieldSelector jsonFieldSelector = JsonFieldSelector.newInstance("attributes/manufacturer");
 

--- a/java/src/test/java/org/eclipse/ditto/client/TestConstants.java
+++ b/java/src/test/java/org/eclipse/ditto/client/TestConstants.java
@@ -217,6 +217,12 @@ public final class TestConstants {
         public static final org.eclipse.ditto.policies.model.Policy POLICY =
                 PoliciesModelFactory.newPolicy(POLICY_JSON_OBJECT);
 
+        public static final JsonObject POLICY_REVISION_ONLY_JSON_OBJECT = JsonObject.of("{\n" +
+                "    \"_revision\": " + 1 + "\n" + "}");
+
+        public static final org.eclipse.ditto.policies.model.Policy REVISION_ONLY_POLICY =
+                PoliciesModelFactory.newPolicy(POLICY_REVISION_ONLY_JSON_OBJECT);
+
     }
 
 }

--- a/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/messaging/internal/WebSocketMessagingProviderTest.java
@@ -83,7 +83,7 @@ public final class WebSocketMessagingProviderTest {
         expectNoMsg(errors);
     }
 
-    @Test(timeout = 10_000)
+    @Test(timeout = 15_000)
     public void serviceUnavailable() throws Exception {
         final int numberOfRecoverableErrors = 3;
         final BlockingQueue<ServerSocket> serverSocket = new LinkedBlockingQueue<>();


### PR DESCRIPTION
Adds the possibility to specify options and fields (that should be returned in the response) for the RetrievePolicy API.
Implementation in ditto backend: https://github.com/eclipse/ditto/pull/1358