### PR TITLE
Bugfix/search thread leak

### DIFF
--- a/java/src/main/java/org/eclipse/ditto/client/streaming/SpliteratorSubscriber.java
+++ b/java/src/main/java/org/eclipse/ditto/client/streaming/SpliteratorSubscriber.java
@@ -16,10 +16,13 @@ import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,6 +32,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import javax.annotation.Nullable;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -54,6 +59,7 @@ public final class SpliteratorSubscriber<T> implements Subscriber<T>, Spliterato
     private final AtomicInteger splits;
     private final AtomicInteger quota;
     private final AtomicBoolean cancelled;
+    @Nullable private volatile ExecutorService subscriptionExecutor;
 
     private SpliteratorSubscriber(final long timeoutMillis, final int bufferSize, final int batchSize) {
         // reserve 2*bufferSize+1 space in buffer for <=bufferSize elements and bufferSize+1 EOS markers
@@ -110,6 +116,10 @@ public final class SpliteratorSubscriber<T> implements Subscriber<T>, Spliterato
             previousSubscription = subscription.get();
             if (previousSubscription == null) {
                 subscription.set(s);
+                if (s instanceof ThingSearchSubscription) {
+                    subscriptionExecutor = Executors.newSingleThreadExecutor();
+                    ((ThingSearchSubscription) s).setSingleThreadedExecutor(subscriptionExecutor);
+                }
             }
         }
         if (previousSubscription == null) {
@@ -130,22 +140,22 @@ public final class SpliteratorSubscriber<T> implements Subscriber<T>, Spliterato
     @Override
     public void onError(final Throwable t) {
         LOGGER.trace("onError", t);
-        cancel();
+        goToCancelledState();
         addErrors(t);
     }
 
     @Override
     public void onComplete() {
         LOGGER.trace("onComplete");
-        cancel();
+        goToCancelledState();
         addEos();
     }
 
-    private void cancel() {
-        cancelled.set(true);
-        final Subscription s = subscription.get();
-        if (s != null) {
-            s.cancel();
+    private void goToCancelledState() {
+        if (!cancelled.getAndSet(true)) {
+            if (subscriptionExecutor != null) {
+                Objects.requireNonNull(subscriptionExecutor).shutdown();
+            }
         }
     }
 
@@ -156,7 +166,11 @@ public final class SpliteratorSubscriber<T> implements Subscriber<T>, Spliterato
         try {
             consumer.accept(element);
         } catch (final RuntimeException e) {
-            cancel();
+            final Subscription s = subscription.get();
+            if (s != null) {
+                s.cancel();
+            }
+            goToCancelledState();
             addErrors(e);
             throw e;
         }

--- a/java/src/main/java/org/eclipse/ditto/client/streaming/ThingSearchSubscription.java
+++ b/java/src/main/java/org/eclipse/ditto/client/streaming/ThingSearchSubscription.java
@@ -66,7 +66,6 @@ public final class ThingSearchSubscription implements Subscription {
         cancelled = new AtomicBoolean(false);
         busSubscription = new AtomicReference<>();
 
-        // not shutdown to handle queued messages; will be shutdown by garbage collector
         singleThreadedExecutorService = Executors.newSingleThreadExecutor();
     }
 
@@ -134,6 +133,7 @@ public final class ThingSearchSubscription implements Subscription {
                 subscriber.onError(timeoutError);
             }
         });
+        singleThreadedExecutorService.shutdown();
     }
 
     // called by bus

--- a/java/src/test/java/org/eclipse/ditto/client/streaming/ThingSearchPublisherTest.java
+++ b/java/src/test/java/org/eclipse/ditto/client/streaming/ThingSearchPublisherTest.java
@@ -63,7 +63,7 @@ public final class ThingSearchPublisherTest extends AbstractDittoClientTest {
         final RequestFromSubscription futileRequest = expectMsgClass(RequestFromSubscription.class);
         reply(SubscriptionComplete.of(subscriptionId, futileRequest.getDittoHeaders()));
         subscriberFuture.get(1L, TimeUnit.SECONDS);
-        executor.shutdown();
+        executor.shutdownNow();
         assertThat(subscriberFuture).isCompletedWithValue(expectedResult);
     }
 }


### PR DESCRIPTION
Fix thread leak when using the search API for some JVMs that do not shut down single-threaded executors when they become unreachable.

The present solution is transferring ownership of the single-threaded executors from the `Subscription` objects to the `Subscriber` objects, because the `Subscription` objects are not notified when the reactive streams complete or fail.

The present solution is not elegant. Consider switching to the `Cleaner` interface after upgrading to Java 9 or above.